### PR TITLE
Persist Sketch Between Frames 

### DIFF
--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -63,7 +63,6 @@ import SceneKit
     public let UPSIDEDOWN = "upsidedown"
     
     public weak var sketchDelegate: SketchDelegate?
-    public var rect: CGRect = CGRect()
     public var width: CGFloat = 0
     public var height: CGFloat = 0
     public let deviceWidth = UIScreen.main.bounds.width
@@ -77,7 +76,7 @@ import SceneKit
     public var deltaTime: CGFloat = 1/60
     private var lastTime: CGFloat = CGFloat(CACurrentMediaTime())
     var fps: CGFloat = 60
-    var fpsTimer: Timer?
+    var fpsTimer: CADisplayLink?
     
     var strokeWeight: CGFloat = 1
     var isFill: Bool = true
@@ -112,6 +111,9 @@ import SceneKit
 
     var isSetup: Bool = false
     open var context: CGContext?
+    open var prevFrame: CGImage?
+    
+    open var lastContext: CGContext?
     
     var scene: SCNScene = SCNScene()
     var lightNode: SCNNode = SCNNode()
@@ -146,31 +148,43 @@ import SceneKit
         initNotifications()
         sketchDelegate = self as? SketchDelegate
         createCanvas(0, 0, UIScreen.main.bounds.width, UIScreen.main.bounds.height)
+        self.layer.drawsAsynchronously = true
+        UIGraphicsBeginImageContext(CGSize(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height))
+        self.context = UIGraphicsGetCurrentContext()
+        UIGraphicsEndImageContext()
         loop()
     }
-    
     override public func draw(_ rect: CGRect) {
-                
+        //this override is not actually called
+        //but required for the UIView to call the
+        //display function
+    }
+    override public func display(_ layer: CALayer) {
+      
         preDraw3D()
-        
-        self.context = UIGraphicsGetCurrentContext()
+        UIGraphicsPushContext(context!)
         
         if self.context == nil {
             return
         }
-        self.width = rect.width
-        self.height = rect.height
+      
+        self.width = layer.preferredFrameSize().width
+        self.height = layer.preferredFrameSize().height
         if !isSetup{
             sketchDelegate?.setup()
             isSetup = true
         }
         updateTimes()
-        self.rect = rect
         sketchDelegate?.draw()
         
         postDraw3D()
         
         updateTouches()
+        
+        UIGraphicsPopContext()
+        let img = context!.makeImage()
+        layer.contents = img
+        
     }
     
     private func updateTimes() {

--- a/Sources/SwiftProcessing/Core/Sketch3D/Sketch3DEnviroment.swift
+++ b/Sources/SwiftProcessing/Core/Sketch3D/Sketch3DEnviroment.swift
@@ -28,5 +28,7 @@ public extension Sketch {
         self.scene.rootNode.addChildNode(baseTransformationNode)
         self.scene.rootNode.addChildNode(lightNode)
         self.scene.rootNode.addChildNode(cameraNode)
+        
+        self.enable3DMode = true
     }
 }

--- a/Sources/SwiftProcessing/Core/SketchColor.swift
+++ b/Sources/SwiftProcessing/Core/SketchColor.swift
@@ -3,7 +3,7 @@ import UIKit
 public extension Sketch {
 
     func clear() {
-        context?.clear(rect)
+        context?.clear(UIScreen.main.bounds)
     }
 
     func background(_ color: Color) {
@@ -11,7 +11,10 @@ public extension Sketch {
     }
 
     func background(_ v1: CGFloat, _ v2: CGFloat, _ v3: CGFloat, _ a: CGFloat = 255) {
-        backgroundColor = UIColor(red: v1 / 255, green: v2 / 255, blue: v3 / 255, alpha: a / 255)
+        push()
+        fill(v1, v2, v3, a)
+        rect(0, 0, width, height)
+        pop()
     }
 
     func fill(_ color: Color) {

--- a/Sources/SwiftProcessing/Core/SketchStructure.swift
+++ b/Sources/SwiftProcessing/Core/SketchStructure.swift
@@ -4,15 +4,18 @@ public extension Sketch {
 
     func loop() {
         if #available(iOS 10.0, *) {
-            fpsTimer = Timer(timeInterval: Double(1.0 / self.fps), repeats: true, block: {  _ in
-                self.setNeedsDisplay()
-            })
-            RunLoop.main.add(fpsTimer!, forMode: RunLoop.Mode.common)
+           
+            fpsTimer = CADisplayLink(target: self,
+                                            selector: #selector(nextFrame))
+            fpsTimer!.add(to: .current,
+                            forMode: RunLoop.Mode.default)
         } else {
             // Fallback on earlier versions
         }
     }
-
+    @objc func nextFrame(displaylink: CADisplayLink) {
+        self.setNeedsDisplay()
+    }
     func noLoop() {
         fpsTimer!.invalidate()
     }


### PR DESCRIPTION
This work moves the graphics context to an off screen image context, enables asynchronous drawing, and takes advantage of the underlying UIView layer to support the previous frames sketch being carried forward to current frame. This enables the Sketch environment to behave more like a traditional P5 / Processing sketch 