### PR TITLE
millis(). Vector fixes. Time addition. Typo. Private to internal change.

### DIFF
--- a/Playgrounds/Modularity.playground/Pages/Objects and Classes.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Modularity.playground/Pages/Objects and Classes.xcplaygroundpage/Contents.swift
@@ -5,7 +5,7 @@
  
  ## Introduction
  
- In Swift, you may not have noticed it, but we've been working with objects from the very first lesson. The creators of programming languages in the late 1970s and 80s envisioned a way of engaging with coding that mimicked real life interactions. They called this Object oriented programming, or OOP for short.
+ In Swift, you may not have noticed it, but we've been working with objects from the very first lesson. The creators of programming languages in the late 1970s and 80s envisioned a way of engaging with coding that mimicked real life interactions. They called this object oriented programming, or OOP for short.
  
  Object oriented programming allows us to create objects that have certain capabilities and can store certain types of information. The image above will be your introduction to this concept.
  

--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -97,7 +97,8 @@ import SceneKit
     
     public var frameCount: Double = 0
     public var deltaTime: Double = 1/60
-    private var lastTime: Double = CACurrentMediaTime()
+    var lastTime: Double = CACurrentMediaTime()
+    var millsOffset: Int = Int(NSDate().timeIntervalSince1970 * 1000)
     
     var fps: Double = 60
     
@@ -204,6 +205,7 @@ import SceneKit
         UIGraphicsEndImageContext()
         
         self.clearsContextBeforeDrawing = false
+        self.isOpaque = true
         
         loop()
     }
@@ -279,13 +281,6 @@ import SceneKit
             self.context = UIGraphicsGetCurrentContext()
             UIGraphicsEndImageContext()
         }
-    }
-    
-    private func updateTimes() {
-        frameCount =  frameCount + 1
-        let newTime = CACurrentMediaTime()
-        deltaTime = newTime - lastTime
-        lastTime = newTime
     }
     
     /// `endDraw()` is an overridable function that runs after `noLoop()` is run. It can be used for any last minute cleanup after the last `draw()` loop has executed.

--- a/Sources/SwiftProcessing/Core/SketchTime.swift
+++ b/Sources/SwiftProcessing/Core/SketchTime.swift
@@ -1,0 +1,42 @@
+/*
+ * SwiftProcessing: Structure
+ *
+ * This is where the draw loop is structured using CADisplayLink.
+ * This is also where beginDraw() and endDraw() are called.
+ *
+ * */
+
+import Foundation
+import SceneKit
+
+extension Sketch {
+    
+    func updateTimes() {
+        frameCount =  frameCount + 1
+        let newTime = CACurrentMediaTime()
+        deltaTime = newTime - lastTime
+        lastTime = newTime
+    }
+    
+    /// Returns the number of milliseconds since the sketch began running.
+    /// ```
+    /// func draw() {
+    ///   print(millis())
+    /// }
+    /// ```
+    
+    public func millis() -> Int {
+        return Int(Date().timeIntervalSince1970 * 1000 - millsOffset)
+    }
+    
+    // FOR FUTURE CONTRIBUTORS
+    
+    // Processing has many Time & Date functions. These return the date formatted in different ways. The functions would be easy to implement. They are day(), hour(), minute(), month(), second(), and year().
+    
+    // The Date and Calender classes are the best places to start.
+    
+    // Resources: https://coderwall.com/p/b8pz5q/swift-4-current-year-mont-day
+    // https://developer.apple.com/documentation/foundation/date
+    // https://developer.apple.com/documentation/foundation/calendar
+    
+}

--- a/Sources/SwiftProcessing/Core/SketchVector.swift
+++ b/Sources/SwiftProcessing/Core/SketchVector.swift
@@ -35,29 +35,25 @@ public extension Sketch {
         return Vector(x, y)
     }
     
-    open class Vector: CustomStringConvertible {
+    class Vector: CustomStringConvertible {
         public var description: String {
-            if z != nil{
-                return "(\(x), \(y), \(String(describing: z)))"
-            }else{
-                return "(\(x), \(y))"
-            }
+            return "(\(x), \(y), \(z)))"
         }
         
         open var x: Double
         open var y: Double
-        open var z: Double?
+        open var z: Double
         
         public init<X: Numeric, Y: Numeric>(_ x: X, _ y: Y) {
             self.x = x.convert()
             self.y = y.convert()
-            self.z = nil as Double?
+            self.z = 0.0
         }
         
-        public init<X: Numeric, Y: Numeric, Z: Numeric>(_ x: X, _ y: Y, _ z: Z?) {
+        public init<X: Numeric, Y: Numeric, Z: Numeric>(_ x: X, _ y: Y, _ z: Z) {
             self.x = x.convert()
             self.y = y.convert()
-            self.z = z?.convert()
+            self.z = z.convert()
         }
         
         /// Sets the vector object to a 2-dimensional vector with x and y values.
@@ -72,7 +68,7 @@ public extension Sketch {
         open func set<X:Numeric, Y: Numeric>(_ x: X, _ y: Y) {
             self.x = x.convert()
             self.y = y.convert()
-            self.z = nil as Double?
+            self.z = 0.0
         }
         
         /// Sets the vector object to a 3-dimensional vector with x, y, and z values.
@@ -85,10 +81,10 @@ public extension Sketch {
         ///     - y: y-position
         ///     - z: z-position
         
-        open func set<X:Numeric, Y: Numeric, Z: Numeric>(_ x: X, _ y: Y, _ z: Z?) {
+        open func set<X:Numeric, Y: Numeric, Z: Numeric>(_ x: X, _ y: Y, _ z: Z) {
             self.x = x.convert()
             self.y = y.convert()
-            self.z = z?.convert()
+            self.z = z.convert()
         }
         
         /// Sets the vector object to be a copy of another vector object.
@@ -125,7 +121,7 @@ public extension Sketch {
         ///      - right: right operand
         
         public static func + (left: Vector, right: Vector) -> Vector {
-            return Vector(left.x + right.x, left.y + right.y, left.z != nil ? (left.z! + right.z!) : nil)
+            return Vector(left.x + right.x, left.y + right.y, left.z  + right.z)
         }
         
         /// Adds two vectors together.
@@ -138,8 +134,12 @@ public extension Sketch {
         ///      - v2: vector 2
         
         public static func add (_ v1: Vector, _ v2: Vector) -> Vector {
-            return Vector(v1.x + v2.x, v1.y + v2.y,  v1.z != nil ? (v1.z! + v2.z!) : nil)
+            return Vector(v1.x + v2.x, v1.y + v2.y,  v1.z + v2.z)
         }
+        
+        // Anything that modifies the self **and** returns it should be appended with the @discardableResult to minimize compile warnings. We are modifying the self **and** we can assign the result to another variable. That is the source of the error.
+        
+        // Sometime to consider is whether we want these functions to return anything at all. That would also silence the error.
         
         /// Adds two vectors together.
         /// ```
@@ -149,7 +149,7 @@ public extension Sketch {
         /// - Parameters:
         ///      - v: vector  to add
         
-        open func add(_ v: Vector) -> Vector {
+        @discardableResult open func add(_ v: Vector) -> Vector {
             let result = Vector.add(self, v)
             self.set(result)
             return self
@@ -165,7 +165,7 @@ public extension Sketch {
         ///      - y: y  to add
         ///      - z: z  to add
         
-        open func add<X: Numeric, Y: Numeric, Z: Numeric>(_ x: X, _ y: Y, _ z: Z?) -> Vector {
+        open func add<X: Numeric, Y: Numeric, Z: Numeric>(_ x: X, _ y: Y, _ z: Z) -> Vector {
             return Vector.add(self, Vector(x, y, z))
         }
         
@@ -192,7 +192,7 @@ public extension Sketch {
         ///      - right: right operand
         
         public static func - (left: Vector, right: Vector) -> Vector {
-            return Vector(left.x - right.x, left.y - right.y, left.z != nil ? (left.z! - right.z!) : nil)
+            return Vector(left.x - right.x, left.y - right.y, left.z - right.z)
         }
         
         /// Subtracts two vectors from each other.
@@ -205,7 +205,7 @@ public extension Sketch {
         ///      - v2: vector 2
         
         public static func sub (_ v1: Vector, _ v2: Vector) -> Vector {
-            return Vector(v1.x - v2.x, v1.y - v2.y, v1.z != nil ? (v1.z! - v2.z!) : nil)
+            return Vector(v1.x - v2.x, v1.y - v2.y, v1.z - v2.z)
         }
         
         /// Subtracts one vector from another.
@@ -216,7 +216,7 @@ public extension Sketch {
         /// - Parameters:
         ///      - v: vector  to add
         
-        open func sub(_ v: Vector) -> Vector {
+        @discardableResult open func sub(_ v: Vector) -> Vector {
             let result = Vector.sub(self, v)
             self.set(result)
             return self
@@ -258,7 +258,7 @@ public extension Sketch {
         ///      - factor: factor to multiply the vector by
         
         public static func mult<F: Numeric>(_ vector: Vector, _ factor: F) -> Vector {
-            return Vector(vector.x * factor.convert(), vector.y * factor.convert(), vector.z != nil ? (vector.z! * factor.convert()) : nil)
+            return Vector(vector.x * factor.convert(), vector.y * factor.convert(), vector.z * factor.convert())
         }
         
         /// Multiplies a vector by a factor.
@@ -270,7 +270,7 @@ public extension Sketch {
         ///      - vector: vector to be multiplied
         ///      - factor: factor to multiply the vector by
         
-        open func mult<F: Numeric>(_ factor: F) -> Vector {
+        @discardableResult open func mult<F: Numeric>(_ factor: F) -> Vector {
             let result = Vector.mult(self, factor)
             self.set(result)
             return self
@@ -299,7 +299,7 @@ public extension Sketch {
         ///      - divisor: divisor to divide the vector by
         
         public static func div<D: Numeric>(_ vector: Vector, _ divisor: D) -> Vector {
-            return Vector(vector.x / divisor.convert(), vector.y / divisor.convert(), vector.z != nil ? (vector.z! / divisor.convert()) : nil)
+            return Vector(vector.x / divisor.convert(), vector.y / divisor.convert(), vector.z / divisor.convert())
         }
         
         /// Divides a vector by a divisor.
@@ -310,7 +310,7 @@ public extension Sketch {
         /// - Parameters:
         ///      - divisor: factor to multiply the vector by
         
-        open func div<D: Numeric>(_ divisor: D) -> Vector {
+        @discardableResult open func div<D: Numeric>(_ divisor: D) -> Vector {
             let result = Vector.div(self, divisor)
             self.set(result)
             return self
@@ -333,7 +333,7 @@ public extension Sketch {
         /// ```
         
         open func magSq() -> Double  {
-            return x * x + y * y + (z != nil ? z! * z! : 0)
+            return x * x + y * y + z * z
         }
         
         /// Returns the dot product of two vectors.
@@ -346,7 +346,7 @@ public extension Sketch {
         ///      - v2: vector 2
         
         public static func dot(_ v1: Vector, _ v2: Vector) -> Double {
-            return v1.x * v2.x + v2.y * v2.y + (v1.z != nil ? (v1.z! * v2.z!) : 0)
+            return v1.x * v2.x + v2.y * v2.y + v1.z * v2.z
         }
         
         /// Returns the dot product of a vector with itself, which is the square of its magnitude.
@@ -372,7 +372,7 @@ public extension Sketch {
         ///      - v2: vector 2
         
         public static func dist(_ v1: Vector, _ v2: Vector) -> Double {
-            return sqrt(pow(v2.x - v1.x, 2) + pow(v2.y - v1.y, 2) + (v1.z != nil ? pow(v2.z! - v1.z!, 2) : 0))
+            return sqrt(pow(v2.x - v1.x, 2) + pow(v2.y - v1.y, 2) + pow(v2.z - v1.z, 2))
         }
         
         /// Returns the distance betwen two vectors.
@@ -396,7 +396,7 @@ public extension Sketch {
         ///      - v1: vector 1
         ///      - v2: vector 2
         
-        open func normalize() -> Vector {
+        @discardableResult open func normalize() -> Vector {
             let len = self.mag()
             if (len != 0){
                 return self.mult(1 / len)
@@ -427,13 +427,30 @@ public extension Sketch {
         ///      - v1: vector 1
         ///      - v2: vector 2
         
-        open func rotate<T: Numeric>(_ theta: T) -> Vector {
+        @discardableResult open func rotate<T: Numeric>(_ theta: T) -> Vector {
             var newHeading = self.heading()
             newHeading += theta.convert();
             let mag = self.mag();
             self.x = cos(newHeading) * mag;
             self.y = sin(newHeading) * mag;
             return self;
+        }
+        
+        /// Limits the magnitude of a vector.
+        /// ```
+        /// // Assigns the vector created by rotating myVector by Math.pi
+        /// let rotated = myVector.rotate(Math.pi)
+        /// ```
+        /// - Parameters:
+        ///      - v1: vector 1
+        ///      - v2: vector 2
+        
+        @discardableResult open func limit<T: Numeric>(_ max: T) -> Vector {
+            if (magSq() > max*max) {
+                normalize()
+                mult(max)
+            }
+            return self
         }
     }
 }

--- a/SwiftProcessing.xcodeproj/project.pbxproj
+++ b/SwiftProcessing.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		1F9EB3E326D152FE00FF3AE5 /* SketchPushPop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9EB3E226D152FE00FF3AE5 /* SketchPushPop.swift */; };
 		1F9EB3E426D152FE00FF3AE5 /* SketchPushPop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9EB3E226D152FE00FF3AE5 /* SketchPushPop.swift */; };
 		1F9EB3E526D152FE00FF3AE5 /* SketchPushPop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9EB3E226D152FE00FF3AE5 /* SketchPushPop.swift */; };
+		1FEBB17426DF3194001F29E3 /* SketchTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FEBB17326DF3194001F29E3 /* SketchTime.swift */; };
 		OBJ_129 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_140 /* SwiftProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_62 /* SwiftProcessingTests.swift */; };
 		OBJ_141 /* VectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_63 /* VectorTests.swift */; };
@@ -261,6 +262,7 @@
 		1F9EB3DE26D152EC00FF3AE5 /* SketchEnums.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SketchEnums.swift; sourceTree = "<group>"; };
 		1F9EB3E226D152FE00FF3AE5 /* SketchPushPop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SketchPushPop.swift; sourceTree = "<group>"; };
 		1F9EB3FC26D153F000FF3AE5 /* Basics.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Basics.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		1FEBB17326DF3194001F29E3 /* SketchTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SketchTime.swift; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		OBJ_62 /* SwiftProcessingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftProcessingTests.swift; sourceTree = "<group>"; };
 		OBJ_63 /* VectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorTests.swift; sourceTree = "<group>"; };
@@ -317,6 +319,7 @@
 				1F1EF8F426ACC7A200A943FF /* SketchSettings.swift */,
 				1F9EB3DA26D1526500FF3AE5 /* SketchStacks.swift */,
 				1F1EF91326ACC7A200A943FF /* SketchStructure.swift */,
+				1FEBB17326DF3194001F29E3 /* SketchTime.swift */,
 				1F1EF8F926ACC7A200A943FF /* SketchTouch.swift */,
 				1F1EF8ED26ACC7A200A943FF /* SketchTransform.swift */,
 				1F1EF91026ACC7A200A943FF /* SketchTypography.swift */,
@@ -672,6 +675,7 @@
 				1F1EF94926ACC7A200A943FF /* ImagePicker.swift in Sources */,
 				1F1EF98226ACC7A200A943FF /* Sketch3DCamera.swift in Sources */,
 				1F1EF98526ACC7A200A943FF /* Sketch3DTexture.swift in Sources */,
+				1FEBB17426DF3194001F29E3 /* SketchTime.swift in Sources */,
 				1F1EF96A26ACC7A200A943FF /* SketchAttributes.swift in Sources */,
 				1F1EF99726ACC7A200A943FF /* SketchVisibility.swift in Sources */,
 				1F1EF9AC26ACC7A200A943FF /* SketchData.swift in Sources */,


### PR DESCRIPTION
## Time
- `millis()` added
- `lastTime` changed to internal.
- `millisOffset` added.
- SketchTime.swift added.
- Breadcrumbs added for future maintainers to add time and date functions.
- `updateTimes()` changed to internal to allow cross-file access.

## Vector
- Dropped the nil value for `z` in 2D vectors. They are now automatically initialized to 0.0. This makes testing for nil within the Vector methods more simple and less prone to error. This makes mathematical sense and all 3D vector math works in 2D with a `z` of 0.0. **NOTE:** The future plan is to use the `??` nil-coalescing operator to default values to 0.0 within methods. The benefit to retaining nil for z as long as possible is unclear to me at this point, but I suspect that in certain situations this may offer a performance benefit. Another approach would be to use a flag that indicates when a vector is 2D that we can use within methods.
- All ternary operators that check for nils have been removed and the Vector method have been simplified. Adding ?? to these will be easy.
- @discardableResult has been added for methods that both return a value *and* modify self. Previously these were causing inaccurate compiler warnings.
- Added a `limit()` function. **NOTE:** Just noticed the quick-help is inaccurate. Will fix in next pull request. Limits the magnitude of the self vector to the value used for the max parameter. Created to accommodate Daniel Shiffman's Flocking example.

## Other
- Small typo in OOP section of Playgrounds.