### PR TITLE
lerpColor(), noise(), noiseDetail() added. background() fixed.

### DIFF
--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -6,6 +6,7 @@
 
 import UIKit
 import SceneKit
+import GameplayKit
 
 // =======================================================================
 // MARK: - Delegate/Protocol
@@ -173,6 +174,13 @@ import SceneKit
     var scnmat: SCNMaterial = SCNMaterial()
     var enable3DMode: Bool = false
     
+    /*
+     * MARK: - NOISE
+     */
+    
+    let noiseSource = GKPerlinNoiseSource()
+    var noise = GKNoise()
+    
     // Used to store references to UIKitViewElements created using SwiftProcessing. Storing references avoids the elements being deallocated from memory. This is needed to have the touch events continue to function
     
     open var viewRefs: [String: UIKitViewElement?] = [:]
@@ -213,6 +221,7 @@ import SceneKit
     // The graphics context also needs to have all of the initial global states set up. Restore was created to mimic Core Graphics restore function, but it also works perfectly to sync up our default SwiftProcessing global states with Core Graphics' states.
     
     private func initializeGlobalContextStates() {
+        noise = GKNoise(noiseSource)
         Sketch.SketchSettings.defaultSettings(self)
     }
     

--- a/Sources/SwiftProcessing/Core/SketchColor.swift
+++ b/Sources/SwiftProcessing/Core/SketchColor.swift
@@ -211,7 +211,8 @@ public extension Sketch {
     ///     - a: An optional alpha value from 0-255. Defaults to 255.
     
     func background<V1: Numeric, A: Numeric>(_ v1: V1, _ a: A) {
-        background(v1, v1, v1, a)
+        let bg = Color(v1, v1, v1, a, .rgb)
+        background(bg)
     }
     
     /// Sets the background color with a single gray value.
@@ -220,7 +221,8 @@ public extension Sketch {
     ///     - v1: A gray value from 0-255.
     
     func background<V1: Numeric>(_ v1: V1) {
-        background(v1, v1, v1, 255.0)
+        let bg = Color(v1, v1, v1, 255, .rgb)
+        background(bg)
     }
     
     /*
@@ -450,6 +452,123 @@ public extension Sketch {
         context?.setBlendMode(CGBlendMode.normal)
     }
     
+    /*
+     * MARK: LERP
+     */
+    
+    /// Blends two colors to find a third color at a point you define between them.
+    /// ```
+    /// func setup() {
+    ///    colorMode(.hsb)
+    ///    stroke(255)
+    ///    background(51)
+    ///    let from = color(218, 165, 32)
+    ///    let to = color(72, 61, 139)
+    ///    colorMode(.hsb) // Try changing to HSB.
+    ///    let interA = lerpColor(from, to, 0.33)
+    ///    let interB = lerpColor(from, to, 0.66)
+    ///    fill(from)
+    ///    rect(10, 20, 20, 60)
+    ///    fill(interA)
+    ///    rect(30, 20, 20, 60)
+    ///    fill(interB)
+    ///    rect(50, 20, 20, 60)
+    ///    fill(to)
+    ///    rect(70, 20, 20, 60)
+    /// }
+    /// ```
+    /// - Parameters:
+    ///     - c1: First color. Should be a SwiftProcessing Color type.
+    ///     - c2: Second color. Should be a SwiftProcessing Color type.
+    ///     - amt: The amoutn to interpolate between two values where 0.0 is the first color and 1.0 is the second color.
+    
+    func lerpColor<T: Numeric>(_ c1: Color, _ c2: Color, _ amt: T) -> Color {
+        
+        let newColor: Color?
+        
+        switch settings.colorMode {
+        case .rgb:
+            let c1_r = c1.red
+            let c1_g = c1.green
+            let c1_b = c1.blue
+            let c1_a = c1.alpha
+            
+            let c2_r = c2.red
+            let c2_g = c2.green
+            let c2_b = c2.blue
+            let c2_a = c2.alpha
+            
+            let cg_amt: CGFloat = amt.convert()
+            
+            let cnst_amt = constrain(cg_amt, 0.0, 1.0)
+            
+            newColor = Color(
+                lerp(c1_r, c2_r, cnst_amt),
+                lerp(c1_g, c2_g, cnst_amt),
+                lerp(c1_b, c2_b, cnst_amt),
+                lerp(c1_a, c2_a, cnst_amt),
+                .rgb
+            )
+        case .hsb:
+            let c1_h = c1.hue
+            let c1_s = c1.saturation
+            let c1_b = c1.brightness
+            let c1_a = c1.alpha
+            
+            let c2_h = c2.hue
+            let c2_s = c2.saturation
+            let c2_b = c2.brightness
+            let c2_a = c2.alpha
+            
+            let cg_amt: CGFloat = amt.convert()
+            
+            let cnst_amt = constrain(cg_amt, 0.0, 1.0)
+            
+            newColor = Color(
+                lerp(c1_h, c2_h, cnst_amt),
+                lerp(c1_s, c2_s, cnst_amt),
+                lerp(c1_b, c2_b, cnst_amt),
+                lerp(c1_a, c2_a, cnst_amt),
+                .hsb
+            )
+        }
+        
+        return newColor ?? Color(0)
+    }
+    
+    /// Blends two colors using color literals to find a third color at a point you define between them. **Note:** Color literals only work in Playgrounds.
+    /// ```
+    /// // Note: This example will only work in a Playground.
+    ///
+    /// func setup() {
+    ///     colorMode(.rgb)
+    ///     stroke(255)
+    ///     background(51)
+    ///     let from = color(#colorLiteral(red: 0.8549019608, green: 0.6470588235, blue: 0.1254901961, alpha: 1))
+    ///     let to = color(72, 61, 139)
+    ///     let to = color(#colorLiteral(red: 0.2823529412, green: 0.2392156863, blue: 0.5450980392, alpha: 1))
+    ///     colorMode(.rgb) // Try changing to HSB.
+    ///     let interA = lerpColor(from, to, 0.33)
+    ///     let interB = lerpColor(from, to, 0.66)
+    ///     fill(from)
+    ///     rect(10, 20, 20, 60)
+    ///     fill(interA)
+    ///     rect(30, 20, 20, 60)
+    ///     fill(interB)
+    ///     rect(50, 20, 20, 60)
+    ///     fill(to)
+    ///     rect(70, 20, 20, 60)
+    /// }
+    /// ```
+    /// - Parameters:
+    ///     - c1: First color. Should be a Playground color literal or a UIColor.
+    ///     - c2: Second color. Should be a Playground color literal or a UIColor.
+    ///     - amt: The amoutn to interpolate between two values where 0.0 is the first color and 1.0 is the second color.
+    
+    func lerpColor<T: Numeric>(_ c1: UIColor, _ c2: UIColor, _ amt: T) -> Color {
+        return lerpColor(Color(c1), Color(c2), amt)
+    }
+
     /*
      * MARK: COLOR
      */

--- a/Sources/SwiftProcessing/Core/SketchRandom.swift
+++ b/Sources/SwiftProcessing/Core/SketchRandom.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import UIKit
+import GameplayKit
 
 // =======================================================================
 // MARK: - RANDOM/NOISE FUNCTIONS
@@ -48,23 +49,163 @@ public extension Sketch {
      */
     
     /*
-     FOR FUTURE CONTRIBUTORS:
-     
      From Wikipedia: https://en.wikipedia.org/wiki/Perlin_noise#Algorithm_detail
      
      An implementation typically involves three steps:
      1 — defining a grid of random gradient vectors.
      2 — computing the dot product between the gradient vectors and their offsets
      3 — and interpolation between these values.
+     
+     To create Processing-style Perlin noise, we're going to leverage Apple's GameplayKit.
+     Source: https://academy.realm.io/posts/tryswift-natalia-berdy-random-talk-consistent-world-noise-swift-gamekit-ios/
+     Source: https://developer.apple.com/documentation/gameplaykit/gknoisemap
+     
+     GameplayKit's GKPerlinNoiseSource() has several properties we can manipulate. Here's how they map to Processing's ecosystem:
+     
+     noiseSource.frequency = 1 // ?
+     noiseSource.octaveCount = 6 // The lod parameter in noiseDetail() in Processing. Default in Processing is 4, but we're sticking with Apple's default of 6.
+     noiseSource.lacunarity = 2 // ?
+     noiseSource.persistence = 0.5 // The falloff paremeter in noiseDetail in Processing.
+     
      */
     
-    /// Perlin Noise
+    /// Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overall intensity of the noise, whereas higher octaves create finer-grained details in the noise sequence.
+    /// By default, noise is computed over 6 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the first octave. This falloff amount can be changed by adding an additional function parameter. For example, a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. While any number between 0.0 and 1.0 is valid, note that values greater than 0.5 may result in `noise()` returning values greater than 1.0.
+    /// By changing these parameters, the signal created by the `noise()` function can be adapted to fit very specific needs and characteristics.
+    /// ```
+    /// var xoff = 0.0
+    ///
+    /// func setup() {
+    /// }
+    ///
+    /// func draw() {
+    ///   background(204)
+    ///   xoff = xoff + 0.01
+    ///   let n = noise(xoff) * width
+    ///   line(n, 0, n, height)
+    /// }
+    /// ```
+    /// - Parameters:
+    ///    - detail: number of octaves to be used by the noise
+    
+    func noiseDetail<D: Numeric>(_ detail: D) {
+        let i_detail: Int = detail.convert()
+        if i_detail > 0 {
+            noiseSource.octaveCount = i_detail
+        }
+    }
+    
+    /// Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overall intensity of the noise, whereas higher octaves create finer-grained details in the noise sequence.
+    /// By default, noise is computed over 6 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the first octave. This falloff amount can be changed by adding an additional function parameter. For example, a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. While any number between 0.0 and 1.0 is valid, note that values greater than 0.5 may result in `noise()` returning values greater than 1.0.
+    /// By changing these parameters, the signal created by the `noise()` function can be adapted to fit very specific needs and characteristics.
     /// ```
     /// // Example
     /// ```
     /// - Parameters:
-    ///   - tk: tk
-
+    ///   - detail: number of octaves to be used by the noise
+    ///   - falloff: falloff factor for each octave
+    
+    func noiseDetail<D: Numeric, F: Numeric>(_ detail: D, _ falloff: F) {
+        let i_detail: Int = detail.convert()
+        let d_falloff: Double = falloff.convert()
+        if i_detail > 0 {
+            noiseSource.octaveCount = i_detail
+        }
+        if d_falloff > 0.0 {
+            noiseSource.persistence = d_falloff
+        }
+    }
+    
+    /// Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural, harmonic succession of numbers than that of the standard `random()` function. It was developed by Ken Perlin in the 1980s and has been used in graphical applications to generate procedural textures, shapes, terrains, and other seemingly organic forms.
+    /// In contrast to the `random()` function, Perlin noise is defined in an infinite n-dimensional space, in which each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. SwiftProcessing can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space, as demonstrated in the first example above. The 2nd and 3rd dimensions can also be interpreted as time.
+    /// The actual noise structure is similar to that of an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, Perlin noise is computed over several octaves which are added together for the final result.
+    /// Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space, the value of the coordinates doesn't matter as such; only the distance between successive coordinates is important (such as when using `noise()` within a loop). As a general rule, the smaller the difference between coordinates, the smoother the resulting noise sequence. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
+    /// ```
+    /// var xoff = 0.0
+    ///
+    /// func setup() {
+    /// }
+    ///
+    /// func draw() {
+    ///     background(204)
+    ///     xoff = xoff + 0.01
+    ///     let n = noise(xoff) * width
+    ///     line(n, 0, n, height)
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - x: x-coordinate in noise space
+    
+    func noise<X: Numeric>(_ x: X) -> Double {
+        let f_x: Float = x.convert()
+        
+        return noise(f_x, 0.0)
+    }
+    
+    /// Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural, harmonic succession of numbers than that of the standard `random()` function. It was developed by Ken Perlin in the 1980s and has been used in graphical applications to generate procedural textures, shapes, terrains, and other seemingly organic forms.
+    /// In contrast to the `random()` function, Perlin noise is defined in an infinite n-dimensional space, in which each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. SwiftProcessing can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space, as demonstrated in the first example above. The 2nd and 3rd dimensions can also be interpreted as time.
+    /// The actual noise structure is similar to that of an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, Perlin noise is computed over several octaves which are added together for the final result.
+    /// Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space, the value of the coordinates doesn't matter as such; only the distance between successive coordinates is important (such as when using `noise()` within a loop). As a general rule, the smaller the difference between coordinates, the smoother the resulting noise sequence. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
+    /// ```
+    /// var noiseScale = 0.02
+    ///
+    /// func setup() {
+    /// }
+    ///
+    /// func draw() {
+    ///     background(0)
+    ///     for x in 0..<Int(width) {
+    ///         let noiseVal = noise((touchX + x)*noiseScale, touchY*noiseScale)
+    ///         stroke(noiseVal*255)
+    ///         line(x, touchY+noiseVal*80, x, height)
+    ///     }
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - x: x-coordinate in noise space
+    ///   - y: y-coordinate in noise space
+    
+    func noise<X: Numeric, Y: Numeric>(_ x: X, _ y: Y) -> Double {
+        let f_x: Float = x.convert()
+        let f_y: Float = y.convert()
+        
+        return noise(f_x, f_y, 0.0)
+    }
+    
+    /// Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural, harmonic succession of numbers than that of the standard `random()` function. It was developed by Ken Perlin in the 1980s and has been used in graphical applications to generate procedural textures, shapes, terrains, and other seemingly organic forms.
+    /// In contrast to the `random()` function, Perlin noise is defined in an infinite n-dimensional space, in which each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. SwiftProcessing can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space, as demonstrated in the first example above. The 2nd and 3rd dimensions can also be interpreted as time.
+    /// The actual noise structure is similar to that of an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, Perlin noise is computed over several octaves which are added together for the final result.
+    /// Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space, the value of the coordinates doesn't matter as such; only the distance between successive coordinates is important (such as when using `noise()` within a loop). As a general rule, the smaller the difference between coordinates, the smoother the resulting noise sequence. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
+    /// ```
+    /// var noiseScale = 0.02
+    ///
+    /// func setup() {
+    /// }
+    ///
+    /// func draw() {
+    ///     background(0)
+    ///     for x in 0..<Int(width) {
+    ///         let noiseVal = noise((touchX + x)*noiseScale, touchY*noiseScale)
+    ///         stroke(noiseVal*255)
+    ///         line(x, touchY+noiseVal*80, x, height)
+    ///     }
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - x: x-coordinate in noise space
+    ///   - y: y-coordinate in noise space
+    ///   - z: z-coordinate in noise space
+    
+    func noise<X: Numeric, Y: Numeric, Z: Numeric>(_ x: X, _ y: Y, _ z: Z) -> Double {
+        let f_x: Float = x.convert()
+        let f_y: Float = y.convert()
+        let d_z: Double = z.convert()
+        
+        // Because there's no push or pop, I'm going to move it and then move it back to get the third dimension. Not sure what this does to performance since we'll be doing this every frame.
+        noise.move(by: vector_double3(0.0, 0.0, d_z))
+        let result = noise.value(atPosition: vector_float2(f_x, f_y))
+        noise.move(by: vector_double3(0.0, 0.0, -d_z))
+        
+        return Double(map(result, -1, 1, 0, 1))
+    }
 }
-
-


### PR DESCRIPTION
## Additions
- `lerpColor()` added. Interpolates between two colors. Option for SwiftProcessing Color type or UIColor, which enables its use with Playground Color Literals.
- `noise()` created to give access to 1, 2, and 3 dimensional Perlin noise. This is implemented through GameplayKit.
- `noiseDetail()` was implemented to allow access to Processing-style noise properties.

## Bug fixes
- `background()` was previously susceptible to changes in `colorMode`. This is inconsistent with Processing, which treats a single parameter background() as always RGB. SwiftProcessing now behaves this way too.