### PR TITLE
noise(), lerpColor(), touch fixes, background() fixes, and default bgcolor fix.

### DIFF
--- a/Playgrounds/Interactivity and Control Flow.playground/Pages/Animated GIFs.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Interactivity and Control Flow.playground/Pages/Animated GIFs.xcplaygroundpage/Contents.swift
@@ -77,5 +77,5 @@ class MySketch: Sketch, SketchDelegate {
 PlaygroundPage.current.needsIndefiniteExecution = true
 PlaygroundPage.current.setLiveView(MySketch())
 //:  ### Credit for image used in Tutorial
-//: Source: [Dansa Serpentina, Gaumont (1900)](https://solarsystem.nasa.gov/resources/795/the-rich-color-variations-of-pluto/?category=planets/dwarf-planets_pluto)\
+//: Source: [Dansa Serpentina, Gaumont (1900)](https://www.youtube.com/watch?v=dGi63uVrJzk)\
 //: [Next](@next)

--- a/Playgrounds/Interactivity and Control Flow.playground/Pages/For and While Loops.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Interactivity and Control Flow.playground/Pages/For and While Loops.xcplaygroundpage/Contents.swift
@@ -87,30 +87,14 @@ class MySketch: Sketch, SketchDelegate {
     
     var topColor = Color(#colorLiteral(red: 0.9686274529, green: 0.78039217, blue: 0.3450980484, alpha: 1))
     var bottomColor = Color(#colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1))
-    
-    var increment = 1
+
+    var increment = 1.0 // Try increasing this increment to see what happens!
     
     func setup() {
-        
-        // Remember that the start and end of a for loop need to be both be integers. Height is a double, so we'll convert it to an integer.
-        
-        for i in stride(from: increment/2, to: Int(height), by: increment) {
-            
-            // To use i in SwiftProcessing functions it should be converted to a Double.
-            
-            let double_i = Double(i)
-            
-            // Creating gradients involves mapping from one color's r,g,and b values to another. Here we create mapped colors that fade from topColor to bottomColor.
-            
-            let red = map(double_i, 0, height, topColor.red, bottomColor.red)
-            let green = map(double_i, 0, height, topColor.green, bottomColor.green)
-            let blue = map(double_i, 0, height, topColor.blue, bottomColor.blue)
-            
-            // Draw lines from the top of the screen to the bottom.
-            
+        for i in stride(from: 0, to: height, by: increment) {
             (strokeWeight(increment),
-            stroke(red, green, blue),
-            line(0, double_i, width, double_i))
+             stroke(lerpColor(topColor, bottomColor, i/height)),
+             line(0, i, width, i))
         }
     }
     

--- a/Playgrounds/Interactivity and Control Flow.playground/Pages/For and While Loops.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Interactivity and Control Flow.playground/Pages/For and While Loops.xcplaygroundpage/Contents.swift
@@ -85,7 +85,7 @@ import UIKit
 
 class MySketch: Sketch, SketchDelegate {
     
-    var topColor = Color(#colorLiteral(red: 0.9686274529, green: 0.78039217, blue: 0.3450980484, alpha: 1))
+    var topColor = Color(#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1))
     var bottomColor = Color(#colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1))
 
     var increment = 1.0 // Try increasing this increment to see what happens!

--- a/Playgrounds/Interactivity and Control Flow.playground/Pages/Map and Lerp.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Interactivity and Control Flow.playground/Pages/Map and Lerp.xcplaygroundpage/Contents.swift
@@ -41,9 +41,19 @@
  
  `lerp(start, stop, amount)`
  
- * `start` - the number you are starting with
- * `stop` - your target number
- * `amount` - how fast you'd like to get there. Between 0.0 to 1.0. Lower is slower and smoother.
+ * `start` - The number you are starting with
+ * `stop` - Your target number
+ * `amount` - How fast you'd like to get there. Between 0.0 to 1.0. Lower is slower and smoother.
+ 
+ ## LerpColor
+ 
+ It's also sometimes useful to be able to interpolate between colors. SwiftProcessing has a convenient function called `lerpColor()` that works in this way. `lerpColor()` has the following syntax:
+ 
+ `lerpColor(color1, color2, amount)`
+ 
+ * `color1` - First color. Color can be either a UIColor, Color Literal, or a SwiftProcessing Color.
+ * `color2` - Second color.
+ * `amount` - A number from 0.0 to 1.0. The closer you are to 0.0, the closer you'll be to `color1`. The closer you are to 1.0, the closer you'll be to `color2`.
  
  ## Let's try out some mapping and lerping! Click and drag around the sketch.
  
@@ -63,12 +73,12 @@ class MySketch: Sketch, SketchDelegate {
     var targetY = 0.0
     
     // We're going to map between two colors from the
-    // top of the screen to the bottom.
-    var topColor = Color(#colorLiteral(red: 0.4745098054, green: 0.8392156959, blue: 0.9764705896, alpha: 1))
-    var bottomColor = Color(#colorLiteral(red: 0.2196078449, green: 0.007843137719, blue: 0.8549019694, alpha: 1))
+    // top of the screen to the bottom to mimic sunset and sunrise.
+    var topColor = Color(#colorLiteral(red: 0.9686274529, green: 0.78039217, blue: 0.3450980484, alpha: 1))
+    var bottomColor = Color(#colorLiteral(red: 0.7450980544, green: 0.1568627506, blue: 0.07450980693, alpha: 1))
     
-    var backgroundTop = Color(#colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1))
-    var backgroundBottom = Color(#colorLiteral(red: 0.9686274529, green: 0.78039217, blue: 0.3450980484, alpha: 1))
+    var backgroundTop = Color(#colorLiteral(red: 0.2392156869, green: 0.6745098233, blue: 0.9686274529, alpha: 1))
+    var backgroundBottom = Color(#colorLiteral(red: 0.009056979678, green: 0, blue: 0.5434187807, alpha: 1))
     
     func setup() {
         // The default starting value for touchX and touchY is 0.0, so it will draw in the corner if we don't change it before draw is called.
@@ -79,11 +89,7 @@ class MySketch: Sketch, SketchDelegate {
     }
     
     func draw() {
-        (background(
-            map(y, 0, height, backgroundTop.red, backgroundBottom.red), /* red */
-            map(y, 0, height, backgroundTop.green, backgroundBottom.green), /* green */
-            map(y, 0, height, backgroundTop.blue, backgroundBottom.blue)  /* blue */
-        ))
+        (background(lerpColor(backgroundTop, backgroundBottom, y/height)))
         
         // Lerp moves us toward our target of touchX and touchY, but slowly.
         
@@ -94,11 +100,7 @@ class MySketch: Sketch, SketchDelegate {
         
         // Because map returns a number, you can use it inside of other functions. Since it can be hard to read, it's OK to separate things over a few lines to make it easier to read. Comments can also help make things more clear.
         
-        fill(
-            map(y, 0, height, topColor.red, bottomColor.red), /* red */
-            map(y, 0, height, topColor.green, bottomColor.green), /* green */
-            map(y, 0, height, topColor.blue, bottomColor.blue)  /* blue */
-        ),
+        fill(lerpColor(topColor, bottomColor, y/height)),
         
         // We feed in our lerped x and y to the circle position. Notice how smooth the motion is.
         

--- a/Playgrounds/Interactivity and Control Flow.playground/Pages/Synthesis—Loops, Curves, and Map.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Interactivity and Control Flow.playground/Pages/Synthesis—Loops, Curves, and Map.xcplaygroundpage/Contents.swift
@@ -20,16 +20,13 @@ import UIKit
 class MySketch: Sketch, SketchDelegate {
     
     let numPoints = 25
-    var randomPoints = [CGPoint]()
+    var randomPoints = [Vector]()
     
-    var xSpeed = [CGFloat]()
-    var ySpeed = [CGFloat]()
+    var xSpeed = [Double]()
+    var ySpeed = [Double]()
     
-    var xDir = [CGFloat]()
-    var yDir = [CGFloat]()
-    
-    // Curve function for quality
-    // or an enum.
+    var xDir = [Double]()
+    var yDir = [Double]()
     
     func setup() {
         
@@ -61,35 +58,34 @@ class MySketch: Sketch, SketchDelegate {
         }
         (endShape(.close))
         
-        // Draw control points as red circles.
+        // Draw control points as rainbow colored circles.
         (fill(255, 0, 0))
         (noStroke())
         for p in randomPoints {
             (fill((map(p.y, 0, height, 0, 360)), 100, 100, 100))
-//            (fill(360, 100, 100))
             (circle(p.x, p.y, 15))
         }
 
         // Move the points according to speed and direction until they hit an edge and then reverse.
         for i in 0..<randomPoints.count {
-            (randomPoints[i].x += (xSpeed[i] * xDir[i]))
-            (randomPoints[i].y += (ySpeed[i] * yDir[i]))
-            if randomPoints[i].x < 0 || randomPoints[i].x > CGFloat(width) {
+            (randomPoints[i].x += xSpeed[i] * xDir[i])
+            (randomPoints[i].y += ySpeed[i] * yDir[i])
+            if randomPoints[i].x < 0 || randomPoints[i].x > width {
                 (xDir[i] *= -1)
             }
             
-            if randomPoints[i].y < 0 || randomPoints[i].y > CGFloat(height) {
+            if randomPoints[i].y < 0 || randomPoints[i].y > height {
                 (yDir[i] *= -1)
             }
         }
     }
     
     // A custom function that returns an array of random points. We'll learn to write our own functions in a future playground!
-    func randomPoints(_ number: Int) -> [CGPoint] {
-        var points = [CGPoint]()
+    func randomPoints(_ number: Int) -> [Vector] {
+        var points = [Vector]()
         
         for _ in 0..<number {
-            (points.append(CGPoint(x: random(width), y: random(height))))
+            (points.append(createVector(random(width), random(height))))
         }
         return points
     }

--- a/Playgrounds/Interactivity and Control Flow.playground/Pages/Touch and Animation.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Interactivity and Control Flow.playground/Pages/Touch and Animation.xcplaygroundpage/Contents.swift
@@ -28,6 +28,18 @@
  `func touchMoved()` - Executes when a finger has moved.\
  `func touchEnded()` - Executes when a finger has left the screen.
  
+ ## SwiftProcessing's Touches Array
+ 
+ Sometimes you need access to all of the touches as an array or count how many touches there are on your multi-touch display. For this you can use `touches`.  Its an array of `Vector`s. You can loop through them with a `for` loop. The code below displays how many touches are on your device's multitouch display.
+ 
+ ```
+ func draw() {
+     clear()
+     let display = "\(touches.count) touches"
+     text(display, 5, 10)
+ }
+ ```
+ 
  ## Let's get interative with touch!
  
  */

--- a/Playgrounds/Interactivity and Control Flow.playground/contents.xcplayground
+++ b/Playgrounds/Interactivity and Control Flow.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='rendered' buildActiveScheme='true' importAppTypes='true'>
+<playground version='6.0' target-platform='ios' display-mode='rendered' buildActiveScheme='true'>
     <pages>
         <page name='Table of Contents'/>
         <page name='Conditional Logic'/>

--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -225,10 +225,6 @@ import GameplayKit
         
         UIGraphicsEndImageContext()
         
-        self.clearsContextBeforeDrawing = false
-        self.isOpaque = true
-        self.backgroundColor = Default.backgroundColor.uiColor()
-        
         loop()
     }
     
@@ -270,6 +266,7 @@ import GameplayKit
         
         // To ensure setup only runs once.
         if !isSetup{
+            background(Default.backgroundColor)
             sketchDelegate?.setup()
             isSetup = true
         }

--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -245,7 +245,6 @@ import GameplayKit
     /// `beginDraw()` sets the global state. It ensures that the Core Graphics context and SwiftProcessing's global settings start out in sync. Overridable if anything needs to be done before `setup()` is run.
     
     open func beginDraw() {
-        background(Default.backgroundColor)
         initializeGlobalContextStates()
     }
     
@@ -267,6 +266,8 @@ import GameplayKit
         UIGraphicsPushContext(context!)
 
         scale(UIScreen.main.scale, UIScreen.main.scale)
+        
+        background(Default.backgroundColor)
         
         // To ensure setup only runs once.
         if !isSetup{

--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -6,6 +6,7 @@
 
 import UIKit
 import SceneKit
+import GameplayKit
 
 // =======================================================================
 // MARK: - Delegate/Protocol
@@ -173,6 +174,13 @@ import SceneKit
     var scnmat: SCNMaterial = SCNMaterial()
     var enable3DMode: Bool = false
     
+    /*
+     * MARK: - NOISE
+     */
+    
+    let noiseSource = GKPerlinNoiseSource()
+    var noise = GKNoise()
+    
     // Used to store references to UIKitViewElements created using SwiftProcessing. Storing references avoids the elements being deallocated from memory. This is needed to have the touch events continue to function
     
     open var viewRefs: [String: UIKitViewElement?] = [:]
@@ -213,6 +221,7 @@ import SceneKit
     // The graphics context also needs to have all of the initial global states set up. Restore was created to mimic Core Graphics restore function, but it also works perfectly to sync up our default SwiftProcessing global states with Core Graphics' states.
     
     private func initializeGlobalContextStates() {
+        noise = GKNoise(noiseSource)
         Sketch.SketchSettings.defaultSettings(self)
     }
     

--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -227,6 +227,7 @@ import GameplayKit
         
         self.clearsContextBeforeDrawing = false
         self.isOpaque = true
+        self.backgroundColor = Default.backgroundColor.uiColor()
         
         loop()
     }
@@ -266,8 +267,6 @@ import GameplayKit
         UIGraphicsPushContext(context!)
 
         scale(UIScreen.main.scale, UIScreen.main.scale)
-        
-        background(Default.backgroundColor)
         
         // To ensure setup only runs once.
         if !isSetup{

--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -130,8 +130,7 @@ import GameplayKit
     open var touched: Bool = false
     open var touchX: Double = -1
     open var touchY: Double = -1
-    
-    // This is the last string-based constant in SwiftProcessing. Leaving this here for future contributors. It needs to be converted to an enum but .self cannot be the name of a member of an enum.
+ 
     var touchMode: TouchMode = .sketch
     var touchRecongizer: UIGestureRecognizer!
     
@@ -184,14 +183,12 @@ import GameplayKit
     
     var noiseSource = GKPerlinNoiseSource()
     var noise = GKNoise()
-//    var noiseMap = GKNoiseMap()
     
     func initNoise(_ size: Int = Default.perlinSize, _ detail: Int = Default.perlinOctaves, _ falloff: Double = Default.perlinFalloff) {
         noiseSource = GKPerlinNoiseSource()
         noiseSource.octaveCount = detail
         noiseSource.persistence = falloff
         noise = GKNoise(noiseSource)
-//        noiseMap = GKNoiseMap(noise, size: vector_double2(Double(size), Double(size)), origin: vector_double2(0.0, 0.0), sampleCount: vector_int2(Int32(size), Int32(size)), seamless: true)
     }
     
     // Used to store references to UIKitViewElements created using SwiftProcessing. Storing references avoids the elements being deallocated from memory. This is needed to have the touch events continue to function
@@ -214,6 +211,7 @@ import GameplayKit
     
     private func initHelper(){
         initTouch()
+        initNoise()
         initNotifications()
         sketchDelegate = self as? SketchDelegate
         createCanvas(0.0, 0.0, UIScreen.main.bounds.width, UIScreen.main.bounds.height)
@@ -233,7 +231,6 @@ import GameplayKit
     private func initializeGlobalContextStates() {
         Sketch.SketchSettings.defaultSettings(self)
     }
-    
     
     // ========================================================
     // MARK: - DRAW LOOP

--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -56,6 +56,7 @@ import GameplayKit
     /// The `Default` struct contains the defaults for the style states that SwiftProcessing keeps track of.
     
     public struct Default {
+        public static let backgroundColor = Color(204)
         public static let colorMode = ColorMode.rgb
         public static let fill = Color(255)
         public static let stroke = Color(0.0)
@@ -72,6 +73,9 @@ import GameplayKit
         public static let textAlign = Alignment.left
         public static let textAlignY = AlignmentY.baseline
         public static let blendMode = CGBlendMode.normal
+        public static let perlinSize = 4096
+        public static let perlinOctaves = 4
+        public static let perlinFalloff = 0.5
     }
     
     
@@ -178,8 +182,17 @@ import GameplayKit
      * MARK: - NOISE
      */
     
-    let noiseSource = GKPerlinNoiseSource()
+    var noiseSource = GKPerlinNoiseSource()
     var noise = GKNoise()
+//    var noiseMap = GKNoiseMap()
+    
+    func initNoise(_ size: Int = Default.perlinSize, _ detail: Int = Default.perlinOctaves, _ falloff: Double = Default.perlinFalloff) {
+        noiseSource = GKPerlinNoiseSource()
+        noiseSource.octaveCount = detail
+        noiseSource.persistence = falloff
+        noise = GKNoise(noiseSource)
+//        noiseMap = GKNoiseMap(noise, size: vector_double2(Double(size), Double(size)), origin: vector_double2(0.0, 0.0), sampleCount: vector_int2(Int32(size), Int32(size)), seamless: true)
+    }
     
     // Used to store references to UIKitViewElements created using SwiftProcessing. Storing references avoids the elements being deallocated from memory. This is needed to have the touch events continue to function
     
@@ -221,7 +234,6 @@ import GameplayKit
     // The graphics context also needs to have all of the initial global states set up. Restore was created to mimic Core Graphics restore function, but it also works perfectly to sync up our default SwiftProcessing global states with Core Graphics' states.
     
     private func initializeGlobalContextStates() {
-        noise = GKNoise(noiseSource)
         Sketch.SketchSettings.defaultSettings(self)
     }
     
@@ -233,6 +245,7 @@ import GameplayKit
     /// `beginDraw()` sets the global state. It ensures that the Core Graphics context and SwiftProcessing's global settings start out in sync. Overridable if anything needs to be done before `setup()` is run.
     
     open func beginDraw() {
+        background(Default.backgroundColor)
         initializeGlobalContextStates()
     }
     

--- a/Sources/SwiftProcessing/Core/SketchCanvas.swift
+++ b/Sources/SwiftProcessing/Core/SketchCanvas.swift
@@ -19,6 +19,7 @@ extension Sketch{
         cg_height = height.convert()
         // Changing to true. isOpaque can improve performance.
         self.isOpaque = true
+        self.backgroundColor = Default.backgroundColor.uiColor()
         self.frame = CGRect(x: cg_x, y: cg_y, width: cg_width, height: cg_height)
     }
     

--- a/Sources/SwiftProcessing/Core/SketchCanvas.swift
+++ b/Sources/SwiftProcessing/Core/SketchCanvas.swift
@@ -19,7 +19,8 @@ extension Sketch{
         cg_height = height.convert()
         // Changing to true. isOpaque can improve performance.
         self.isOpaque = true
-        self.backgroundColor = Default.backgroundColor.uiColor()
+        // Can also improve performance.
+        self.clearsContextBeforeDrawing = false
         self.frame = CGRect(x: cg_x, y: cg_y, width: cg_width, height: cg_height)
     }
     

--- a/Sources/SwiftProcessing/Core/SketchColor.swift
+++ b/Sources/SwiftProcessing/Core/SketchColor.swift
@@ -211,7 +211,8 @@ public extension Sketch {
     ///     - a: An optional alpha value from 0-255. Defaults to 255.
     
     func background<V1: Numeric, A: Numeric>(_ v1: V1, _ a: A) {
-        background(v1, v1, v1, a)
+        let bg = Color(v1, v1, v1, a, .rgb)
+        background(bg)
     }
     
     /// Sets the background color with a single gray value.
@@ -220,7 +221,8 @@ public extension Sketch {
     ///     - v1: A gray value from 0-255.
     
     func background<V1: Numeric>(_ v1: V1) {
-        background(v1, v1, v1, 255.0)
+        let bg = Color(v1, v1, v1, 255, .rgb)
+        background(bg)
     }
     
     /*
@@ -450,6 +452,123 @@ public extension Sketch {
         context?.setBlendMode(CGBlendMode.normal)
     }
     
+    /*
+     * MARK: LERP
+     */
+    
+    /// Blends two colors to find a third color at a point you define between them.
+    /// ```
+    /// func setup() {
+    ///    colorMode(.hsb)
+    ///    stroke(255)
+    ///    background(51)
+    ///    let from = color(218, 165, 32)
+    ///    let to = color(72, 61, 139)
+    ///    colorMode(.hsb) // Try changing to HSB.
+    ///    let interA = lerpColor(from, to, 0.33)
+    ///    let interB = lerpColor(from, to, 0.66)
+    ///    fill(from)
+    ///    rect(10, 20, 20, 60)
+    ///    fill(interA)
+    ///    rect(30, 20, 20, 60)
+    ///    fill(interB)
+    ///    rect(50, 20, 20, 60)
+    ///    fill(to)
+    ///    rect(70, 20, 20, 60)
+    /// }
+    /// ```
+    /// - Parameters:
+    ///     - c1: First color. Should be a SwiftProcessing Color type.
+    ///     - c2: Second color. Should be a SwiftProcessing Color type.
+    ///     - amt: The amoutn to interpolate between two values where 0.0 is the first color and 1.0 is the second color.
+    
+    func lerpColor<T: Numeric>(_ c1: Color, _ c2: Color, _ amt: T) -> Color {
+        
+        let newColor: Color?
+        
+        switch settings.colorMode {
+        case .rgb:
+            let c1_r = c1.red
+            let c1_g = c1.green
+            let c1_b = c1.blue
+            let c1_a = c1.alpha
+            
+            let c2_r = c2.red
+            let c2_g = c2.green
+            let c2_b = c2.blue
+            let c2_a = c2.alpha
+            
+            let cg_amt: CGFloat = amt.convert()
+            
+            let cnst_amt = constrain(cg_amt, 0.0, 1.0)
+            
+            newColor = Color(
+                lerp(c1_r, c2_r, cnst_amt),
+                lerp(c1_g, c2_g, cnst_amt),
+                lerp(c1_b, c2_b, cnst_amt),
+                lerp(c1_a, c2_a, cnst_amt),
+                .rgb
+            )
+        case .hsb:
+            let c1_h = c1.hue
+            let c1_s = c1.saturation
+            let c1_b = c1.brightness
+            let c1_a = c1.alpha
+            
+            let c2_h = c2.hue
+            let c2_s = c2.saturation
+            let c2_b = c2.brightness
+            let c2_a = c2.alpha
+            
+            let cg_amt: CGFloat = amt.convert()
+            
+            let cnst_amt = constrain(cg_amt, 0.0, 1.0)
+            
+            newColor = Color(
+                lerp(c1_h, c2_h, cnst_amt),
+                lerp(c1_s, c2_s, cnst_amt),
+                lerp(c1_b, c2_b, cnst_amt),
+                lerp(c1_a, c2_a, cnst_amt),
+                .hsb
+            )
+        }
+        
+        return newColor ?? Color(0)
+    }
+    
+    /// Blends two colors using color literals to find a third color at a point you define between them. **Note:** Color literals only work in Playgrounds.
+    /// ```
+    /// // Note: This example will only work in a Playground.
+    ///
+    /// func setup() {
+    ///     colorMode(.rgb)
+    ///     stroke(255)
+    ///     background(51)
+    ///     let from = color(#colorLiteral(red: 0.8549019608, green: 0.6470588235, blue: 0.1254901961, alpha: 1))
+    ///     let to = color(72, 61, 139)
+    ///     let to = color(#colorLiteral(red: 0.2823529412, green: 0.2392156863, blue: 0.5450980392, alpha: 1))
+    ///     colorMode(.rgb) // Try changing to HSB.
+    ///     let interA = lerpColor(from, to, 0.33)
+    ///     let interB = lerpColor(from, to, 0.66)
+    ///     fill(from)
+    ///     rect(10, 20, 20, 60)
+    ///     fill(interA)
+    ///     rect(30, 20, 20, 60)
+    ///     fill(interB)
+    ///     rect(50, 20, 20, 60)
+    ///     fill(to)
+    ///     rect(70, 20, 20, 60)
+    /// }
+    /// ```
+    /// - Parameters:
+    ///     - c1: First color. Should be a Playground color literal or a UIColor.
+    ///     - c2: Second color. Should be a Playground color literal or a UIColor.
+    ///     - amt: The amoutn to interpolate between two values where 0.0 is the first color and 1.0 is the second color.
+    
+    func lerpColor<T: Numeric>(_ c1: UIColor, _ c2: UIColor, _ amt: T) -> Color {
+        return lerpColor(Color(c1), Color(c2), amt)
+    }
+
     /*
      * MARK: COLOR
      */

--- a/Sources/SwiftProcessing/Core/SketchRandom.swift
+++ b/Sources/SwiftProcessing/Core/SketchRandom.swift
@@ -56,12 +56,18 @@ public extension Sketch {
      2 — computing the dot product between the gradient vectors and their offsets
      3 — and interpolation between these values.
      
-     To create Processing-style Perlin noise, we're going to leverage Apple's GameplayKit as a stopgap measure. This has a major drawback: Once you set the noise parameters, it does not seem easy to change them. That means that noiseDetail() is fixed and cannot be changed.
+     To create Processing-style Perlin noise, we're going to leverage Apple's GameplayKit as a stopgap measure before implementing our own noise method.
      
-     Source: https://academy.realm.io/posts/tryswift-natalia-berdy-random-talk-consistent-world-noise-swift-gamekit-ios/
-     Source: https://developer.apple.com/documentation/gameplaykit/gknoisemap
-     Source: https://www.hackingwithswift.com/example-code/games/how-to-create-a-random-terrain-tile-map-using-sktilemapnode-and-gkperlinnoisesource
-     Source: https://rtouti.github.io/graphics/perlin-noise-algorithm
+     This currently has two major drawbacks looking for a solution:
+     1 - Once you set the noise parameters, it does not seem easy to change them in the same frame. That means that noiseDetail() is fixed and cannot be changed.
+     2 - It isn't clear to me how to gain access to the 3rd dimension of Perlin noise with GKPerlinNoiseSource().
+     
+     Sources:
+     https://academy.realm.io/posts/tryswift-natalia-berdy-random-talk-consistent-world-noise-swift-gamekit-ios/
+     https://developer.apple.com/documentation/gameplaykit/gknoisemap
+     https://www.hackingwithswift.com/example-code/games/how-to-create-a-random-terrain-tile-map-using-sktilemapnode-and-gkperlinnoisesource
+     https://rtouti.github.io/graphics/perlin-noise-algorithm
+     https://mrl.cs.nyu.edu/~perlin/doc/oscar.html
      
      GameplayKit's GKPerlinNoiseSource() has several properties we can manipulate. Here's how they map to Processing's ecosystem:
      
@@ -91,6 +97,9 @@ public extension Sketch {
     /// - Parameters:
     ///    - detail: number of octaves to be used by the noise
     
+    // To be implemented later.
+    
+    /*
     func noiseDetail<D: Numeric>(_ detail: D) {
         let i_detail: Int = detail.convert()
         noiseSource = GKPerlinNoiseSource()
@@ -99,6 +108,7 @@ public extension Sketch {
             settings.perlinOctaves = i_detail
         }
     }
+    */
     
     /// Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overall intensity of the noise, whereas higher octaves create finer-grained details in the noise sequence.
     /// By default, noise is computed over 6 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the first octave. This falloff amount can be changed by adding an additional function parameter. For example, a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. While any number between 0.0 and 1.0 is valid, note that values greater than 0.5 may result in `noise()` returning values greater than 1.0.
@@ -110,6 +120,8 @@ public extension Sketch {
     ///   - detail: number of octaves to be used by the noise
     ///   - falloff: falloff factor for each octave
     
+    // To be implemented later.
+    /*
     func noiseDetail<D: Numeric, F: Numeric>(_ detail: D, _ falloff: F) {
         let i_detail: Int = detail.convert()
         let d_falloff: Double = falloff.convert()
@@ -120,6 +132,7 @@ public extension Sketch {
             settings.perlinFalloff = d_falloff
         }
     }
+    */
     
     /// Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural, harmonic succession of numbers than that of the standard `random()` function. It was developed by Ken Perlin in the 1980s and has been used in graphical applications to generate procedural textures, shapes, terrains, and other seemingly organic forms.
     /// In contrast to the `random()` function, Perlin noise is defined in an infinite n-dimensional space, in which each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. SwiftProcessing can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space, as demonstrated in the first example above. The 2nd and 3rd dimensions can also be interpreted as time.
@@ -174,7 +187,9 @@ public extension Sketch {
         let f_x: Float = x.convert()
         let f_y: Float = y.convert()
         
-        return noise(f_x, f_y, 0.0)
+        let result = noise.value(atPosition: vector_float2(f_x, f_y))
+        
+        return Double(map(result, -1, 1, 0, 1))
     }
     
     /// Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural, harmonic succession of numbers than that of the standard `random()` function. It was developed by Ken Perlin in the 1980s and has been used in graphical applications to generate procedural textures, shapes, terrains, and other seemingly organic forms.
@@ -201,6 +216,8 @@ public extension Sketch {
     ///   - y: y-coordinate in noise space
     ///   - z: z-coordinate in noise space
     
+    // To be implemented later.
+    /*
     func noise<X: Numeric, Y: Numeric, Z: Numeric>(_ x: X, _ y: Y, _ z: Z) -> Double {
         let f_x: Float = x.convert()
         let f_y: Float = y.convert()
@@ -217,4 +234,5 @@ public extension Sketch {
         
         return Double(map(result, -1, 1, 0, 1))
     }
+    */
 }

--- a/Sources/SwiftProcessing/Core/SketchRandom.swift
+++ b/Sources/SwiftProcessing/Core/SketchRandom.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import UIKit
+import GameplayKit
 
 // =======================================================================
 // MARK: - RANDOM/NOISE FUNCTIONS
@@ -48,23 +49,163 @@ public extension Sketch {
      */
     
     /*
-     FOR FUTURE CONTRIBUTORS:
-     
      From Wikipedia: https://en.wikipedia.org/wiki/Perlin_noise#Algorithm_detail
      
      An implementation typically involves three steps:
      1 — defining a grid of random gradient vectors.
      2 — computing the dot product between the gradient vectors and their offsets
      3 — and interpolation between these values.
+     
+     To create Processing-style Perlin noise, we're going to leverage Apple's GameplayKit.
+     Source: https://academy.realm.io/posts/tryswift-natalia-berdy-random-talk-consistent-world-noise-swift-gamekit-ios/
+     Source: https://developer.apple.com/documentation/gameplaykit/gknoisemap
+     
+     GameplayKit's GKPerlinNoiseSource() has several properties we can manipulate. Here's how they map to Processing's ecosystem:
+     
+     noiseSource.frequency = 1 // ?
+     noiseSource.octaveCount = 6 // The lod parameter in noiseDetail() in Processing. Default in Processing is 4, but we're sticking with Apple's default of 6.
+     noiseSource.lacunarity = 2 // ?
+     noiseSource.persistence = 0.5 // The falloff paremeter in noiseDetail in Processing.
+     
      */
     
-    /// Perlin Noise
+    /// Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overall intensity of the noise, whereas higher octaves create finer-grained details in the noise sequence.
+    /// By default, noise is computed over 6 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the first octave. This falloff amount can be changed by adding an additional function parameter. For example, a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. While any number between 0.0 and 1.0 is valid, note that values greater than 0.5 may result in `noise()` returning values greater than 1.0.
+    /// By changing these parameters, the signal created by the `noise()` function can be adapted to fit very specific needs and characteristics.
+    /// ```
+    /// var xoff = 0.0
+    ///
+    /// func setup() {
+    /// }
+    ///
+    /// func draw() {
+    ///   background(204)
+    ///   xoff = xoff + 0.01
+    ///   let n = noise(xoff) * width
+    ///   line(n, 0, n, height)
+    /// }
+    /// ```
+    /// - Parameters:
+    ///    - detail: number of octaves to be used by the noise
+    
+    func noiseDetail<D: Numeric>(_ detail: D) {
+        let i_detail: Int = detail.convert()
+        if i_detail > 0 {
+            noiseSource.octaveCount = i_detail
+        }
+    }
+    
+    /// Adjusts the character and level of detail produced by the Perlin noise function. Similar to harmonics in physics, noise is computed over several octaves. Lower octaves contribute more to the output signal and as such define the overall intensity of the noise, whereas higher octaves create finer-grained details in the noise sequence.
+    /// By default, noise is computed over 6 octaves with each octave contributing exactly half than its predecessor, starting at 50% strength for the first octave. This falloff amount can be changed by adding an additional function parameter. For example, a falloff factor of 0.75 means each octave will now have 75% impact (25% less) of the previous lower octave. While any number between 0.0 and 1.0 is valid, note that values greater than 0.5 may result in `noise()` returning values greater than 1.0.
+    /// By changing these parameters, the signal created by the `noise()` function can be adapted to fit very specific needs and characteristics.
     /// ```
     /// // Example
     /// ```
     /// - Parameters:
-    ///   - tk: tk
-
+    ///   - detail: number of octaves to be used by the noise
+    ///   - falloff: falloff factor for each octave
+    
+    func noiseDetail<D: Numeric, F: Numeric>(_ detail: D, _ falloff: F) {
+        let i_detail: Int = detail.convert()
+        let d_falloff: Double = falloff.convert()
+        if i_detail > 0 {
+            noiseSource.octaveCount = i_detail
+        }
+        if d_falloff > 0.0 {
+            noiseSource.persistence = d_falloff
+        }
+    }
+    
+    /// Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural, harmonic succession of numbers than that of the standard `random()` function. It was developed by Ken Perlin in the 1980s and has been used in graphical applications to generate procedural textures, shapes, terrains, and other seemingly organic forms.
+    /// In contrast to the `random()` function, Perlin noise is defined in an infinite n-dimensional space, in which each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. SwiftProcessing can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space, as demonstrated in the first example above. The 2nd and 3rd dimensions can also be interpreted as time.
+    /// The actual noise structure is similar to that of an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, Perlin noise is computed over several octaves which are added together for the final result.
+    /// Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space, the value of the coordinates doesn't matter as such; only the distance between successive coordinates is important (such as when using `noise()` within a loop). As a general rule, the smaller the difference between coordinates, the smoother the resulting noise sequence. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
+    /// ```
+    /// var xoff = 0.0
+    ///
+    /// func setup() {
+    /// }
+    ///
+    /// func draw() {
+    ///     background(204)
+    ///     xoff = xoff + 0.01
+    ///     let n = noise(xoff) * width
+    ///     line(n, 0, n, height)
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - x: x-coordinate in noise space
+    
+    func noise<X: Numeric>(_ x: X) -> Double {
+        let f_x: Float = x.convert()
+        
+        return noise(f_x, 0.0)
+    }
+    
+    /// Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural, harmonic succession of numbers than that of the standard `random()` function. It was developed by Ken Perlin in the 1980s and has been used in graphical applications to generate procedural textures, shapes, terrains, and other seemingly organic forms.
+    /// In contrast to the `random()` function, Perlin noise is defined in an infinite n-dimensional space, in which each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. SwiftProcessing can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space, as demonstrated in the first example above. The 2nd and 3rd dimensions can also be interpreted as time.
+    /// The actual noise structure is similar to that of an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, Perlin noise is computed over several octaves which are added together for the final result.
+    /// Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space, the value of the coordinates doesn't matter as such; only the distance between successive coordinates is important (such as when using `noise()` within a loop). As a general rule, the smaller the difference between coordinates, the smoother the resulting noise sequence. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
+    /// ```
+    /// var noiseScale = 0.02
+    ///
+    /// func setup() {
+    /// }
+    ///
+    /// func draw() {
+    ///     background(0)
+    ///     for x in 0..<Int(width) {
+    ///         let noiseVal = noise((touchX + x)*noiseScale, touchY*noiseScale)
+    ///         stroke(noiseVal*255)
+    ///         line(x, touchY+noiseVal*80, x, height)
+    ///     }
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - x: x-coordinate in noise space
+    ///   - y: y-coordinate in noise space
+    
+    func noise<X: Numeric, Y: Numeric>(_ x: X, _ y: Y) -> Double {
+        let f_x: Float = x.convert()
+        let f_y: Float = y.convert()
+        
+        return noise(f_x, f_y, 0.0)
+    }
+    
+    /// Returns the Perlin noise value at specified coordinates. Perlin noise is a random sequence generator producing a more natural, harmonic succession of numbers than that of the standard `random()` function. It was developed by Ken Perlin in the 1980s and has been used in graphical applications to generate procedural textures, shapes, terrains, and other seemingly organic forms.
+    /// In contrast to the `random()` function, Perlin noise is defined in an infinite n-dimensional space, in which each pair of coordinates corresponds to a fixed semi-random value (fixed only for the lifespan of the program). The resulting value will always be between 0.0 and 1.0. SwiftProcessing can compute 1D, 2D and 3D noise, depending on the number of coordinates given. The noise value can be animated by moving through the noise space, as demonstrated in the first example above. The 2nd and 3rd dimensions can also be interpreted as time.
+    /// The actual noise structure is similar to that of an audio signal, in respect to the function's use of frequencies. Similar to the concept of harmonics in physics, Perlin noise is computed over several octaves which are added together for the final result.
+    /// Another way to adjust the character of the resulting sequence is the scale of the input coordinates. As the function works within an infinite space, the value of the coordinates doesn't matter as such; only the distance between successive coordinates is important (such as when using `noise()` within a loop). As a general rule, the smaller the difference between coordinates, the smoother the resulting noise sequence. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
+    /// ```
+    /// var noiseScale = 0.02
+    ///
+    /// func setup() {
+    /// }
+    ///
+    /// func draw() {
+    ///     background(0)
+    ///     for x in 0..<Int(width) {
+    ///         let noiseVal = noise((touchX + x)*noiseScale, touchY*noiseScale)
+    ///         stroke(noiseVal*255)
+    ///         line(x, touchY+noiseVal*80, x, height)
+    ///     }
+    /// }
+    /// ```
+    /// - Parameters:
+    ///   - x: x-coordinate in noise space
+    ///   - y: y-coordinate in noise space
+    ///   - z: z-coordinate in noise space
+    
+    func noise<X: Numeric, Y: Numeric, Z: Numeric>(_ x: X, _ y: Y, _ z: Z) -> Double {
+        let f_x: Float = x.convert()
+        let f_y: Float = y.convert()
+        let d_z: Double = z.convert()
+        
+        // Because there's no push or pop, I'm going to move it and then move it back to get the third dimension. Not sure what this does to performance since we'll be doing this every frame.
+        noise.move(by: vector_double3(0.0, 0.0, d_z))
+        let result = noise.value(atPosition: vector_float2(f_x, f_y))
+        noise.move(by: vector_double3(0.0, 0.0, -d_z))
+        
+        return Double(map(result, -1, 1, 0, 1))
+    }
 }
-
-

--- a/Sources/SwiftProcessing/Core/SketchSettings.swift
+++ b/Sources/SwiftProcessing/Core/SketchSettings.swift
@@ -39,6 +39,10 @@ public extension Sketch{
         var textAlignY = Default.textAlignY
         var blendMode = Default.blendMode
         
+        var perlinSize = Default.perlinSize
+        var perlinOctaves = Default.perlinOctaves
+        var perlinFalloff = Default.perlinFalloff
+        
         // Re: textMode – A bitmap mode could be done using CTLineDraw from Core Text.
         // Source 1: https://developer.apple.com/documentation/coretext/1511145-ctlinedraw
         // Source 2: https://blog.krzyzanowskim.com/2020/07/13/coretext-swift-academy-part-3/
@@ -62,6 +66,7 @@ public extension Sketch{
             sketch.textSize(textSize)
             sketch.textLeading(textLeading)
             sketch.textAlign(textAlign)
+            // Leaving Perlin settings off for now because they are not really global states that need to be tracked.
         }
         
         public func debugSettings() {

--- a/Sources/SwiftProcessing/Core/SketchTouch.swift
+++ b/Sources/SwiftProcessing/Core/SketchTouch.swift
@@ -66,7 +66,6 @@ extension Sketch: UIGestureRecognizerDelegate {
         // Step 2: If a touch started, then execute touchStarted(), update touchX and touchY, and add it to the touches array so it's accurately collecting all touches.
         if isTouchStarted {
             let startTouch = touchRecongizer.location(ofTouch: 0, in: self)
-            print("touchStarted at \(startTouch)")
             touchX = Double(startTouch.x)
             touchY = Double(startTouch.y)
             let startTouchV = createVector(startTouch.x, startTouch.y)

--- a/Sources/SwiftProcessing/Core/SketchTouch.swift
+++ b/Sources/SwiftProcessing/Core/SketchTouch.swift
@@ -63,12 +63,16 @@ extension Sketch: UIGestureRecognizerDelegate {
         
         print(newTouches)
         
-        // Step 2: If a touch started, then execute touchStarted()
+        // Step 2: If a touch started, then execute touchStarted(), update touchX and touchY, and add it to the touches array so it's accurately collecting all touches.
         if isTouchStarted {
-            sketchDelegate?.touchStarted?()
             let startTouch = touchRecongizer.location(ofTouch: 0, in: self)
+            print("touchStarted at \(startTouch)")
+            touchX = Double(startTouch.x)
+            touchY = Double(startTouch.y)
             let startTouchV = createVector(startTouch.x, startTouch.y)
-            newTouches.insert(startTouchV, at: 0)
+            touches.insert(startTouchV, at: 0)
+            
+            sketchDelegate?.touchStarted?()
         }
         
         // Step 3: If the touch is moving, then execute touchMoved()

--- a/Sources/SwiftProcessing/Core/SketchTouch.swift
+++ b/Sources/SwiftProcessing/Core/SketchTouch.swift
@@ -57,13 +57,18 @@ extension Sketch: UIGestureRecognizerDelegate {
             return // This cuts out of the function.
         }
         
-        let newTouches = (0...touchRecongizer.numberOfTouches - 1)
+        var newTouches = (0...touchRecongizer.numberOfTouches - 1)
             .map({touchRecongizer.location(ofTouch: $0, in: self)})
             .map({createVector($0.x, $0.y)})
+        
+        print(newTouches)
         
         // Step 2: If a touch started, then execute touchStarted()
         if isTouchStarted {
             sketchDelegate?.touchStarted?()
+            let startTouch = touchRecongizer.location(ofTouch: 0, in: self)
+            let startTouchV = createVector(startTouch.x, startTouch.y)
+            newTouches.insert(startTouchV, at: 0)
         }
         
         // Step 3: If the touch is moving, then execute touchMoved()

--- a/Sources/SwiftProcessing/Core/SketchTouch.swift
+++ b/Sources/SwiftProcessing/Core/SketchTouch.swift
@@ -61,23 +61,21 @@ extension Sketch: UIGestureRecognizerDelegate {
             .map({touchRecongizer.location(ofTouch: $0, in: self)})
             .map({createVector($0.x, $0.y)})
         
-        print(newTouches)
-        
         // Step 2: If a touch started, then execute touchStarted(), update touchX and touchY, and add it to the touches array so it's accurately collecting all touches.
         if isTouchStarted {
+ 
             let startTouch = touchRecongizer.location(ofTouch: 0, in: self)
             touchX = Double(startTouch.x)
             touchY = Double(startTouch.y)
+            sketchDelegate?.touchStarted?()
             let startTouchV = createVector(startTouch.x, startTouch.y)
             touches.insert(startTouchV, at: 0)
-            
-            sketchDelegate?.touchStarted?()
         }
         
         // Step 3: If the touch is moving, then execute touchMoved()
         let moveThreshold: Double = 1.0
         if newTouches.count == touches.count {
-            var totalDiff: Double = 0
+            var totalDiff: Double = 0.0
             for (i, oldTouch) in touches.enumerated() {
                 totalDiff += oldTouch.dist(newTouches[i])
             }


### PR DESCRIPTION
## Additions
- `lerpColor()` added. Interpolates between two colors. Option for SwiftProcessing Color type or UIColor, which enables its use with Playground Color Literals.
- `noise()` created to give access to 1 and 2 dimensional Perlin noise. This is implemented through GameplayKit. 3D noise remains an open issue. This addresses #103 .
- Stubs and quick-help created for `noiseDetail()` but changing the parameters to GameplayKit's `GKPerlinNoiseSource()` does not seem to work at the moment. This is an ongoing issue, but the stubs have been left in the code along with relevant research.
- It may be a good idea to implement a custom SwiftProcessing Perlin improved noise algorithm in the future, but this will at least give access to 2D noise for users for now.

## Bug fixes
- Touch now accurately reflects touch at when it starts, moves, and ends. The `touches` array now properly captures initial touch. Test code created for this purpose by @jjkaufman in a previous discussion #107 functions as expected.
- Previously there was no default background color set. A new Sketch would simply be transparent. This caused unexpected behavior and differences between Playgrounds and apps. Now every sketch defaults to the background color \#CCCCCC, which is consistent with Processing. 
- `background()` was previously susceptible to changes in `colorMode`. This is inconsistent with Processing, which treats a single parameter background() as always RGB. SwiftProcessing now behaves this way too.