### PR TITLE
Typography and Vector fixes.

### DIFF
--- a/Playgrounds/Basics.playground/Pages/Getting Started.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Basics.playground/Pages/Getting Started.xcplaygroundpage/Contents.swift
@@ -76,7 +76,7 @@ import PlaygroundSupport
 //: Code runs from top to bottom. Learning how to follow the steps of your code is one of the most important skills you'll learn!
 //: Functions are chunks of code that do actions. Eventually you'll write your own functions, but for now Processing sketch's are made up of two fundamental functions.
 //: 1. `func setup()` - This happens once at the very beginning of your sketch. Whatever commands you write in here will be called when your program launches. That's why it's called setup! It's for settin things up.
-//:  2. `func draw()` - The draw function gets called in a loop. By default it runs at 60 frames per second.
+//:  2. `func draw()` - The draw function gets called in a loop. By default it runs at 60 frames per second. In this Sketch, we allow our background to persist by not clearing it with the `background()` function every frame. If you want to clear your background and get rid of the trails, just set your background color at the begining of your `draw()`.
 // Note: This sketch is being sped up by the use of parentheses around each statement.
 
 class MySketch: Sketch, SketchDelegate {
@@ -88,6 +88,7 @@ class MySketch: Sketch, SketchDelegate {
     }
 
     func draw() {
+        // Try moving background() here to clear the background every frame.
         (noStroke(),
         // Draw a circle wherever the screen is touched.
         // Try changing 25 to some other number and see what happens!

--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -67,9 +67,9 @@ import GameplayKit
         public static let rectMode = ShapeMode.corner
         public static let ellipseMode = ShapeMode.center
         public static let imageMode = ShapeMode.corner
-        public static let textFont = "HelveticaNeue-Thin"
-        public static let textSize = 32.0 // Processing is 12, so let's test this out.
-        public static let textLeading = 37.0 // Processing is 14. This is a similar increase.
+        public static let textFont = "HelveticaNeue"
+        public static let textSize = 32.0
+        public static let textLeading = 38.4 // Generally 120% of size. This is derived from Adobe's default treatment of leading.
         public static let textAlign = Alignment.left
         public static let textAlignY = AlignmentY.baseline
         public static let blendMode = CGBlendMode.normal
@@ -139,6 +139,36 @@ import GameplayKit
     
     var isSetup: Bool = false
     open var context: CGContext?
+    
+    /*
+     * MARK: - TEXT/TYPOGRAPHY
+     */
+    
+    var paragraphStyle: NSMutableParagraphStyle?
+    var attributes: [NSAttributedString.Key: Any] = [:]
+    
+    func setTextAttributes() {
+        paragraphStyle = NSMutableParagraphStyle()
+        
+        switch settings.textAlign {
+        case .left:
+            paragraphStyle?.alignment = .left
+        case .right:
+            paragraphStyle?.alignment = .right
+        case .center:
+            paragraphStyle?.alignment = .center
+        }
+    
+        paragraphStyle?.lineSpacing = CGFloat(settings.textLeading)
+        
+        attributes = [
+            .font: UIFont(name: settings.textFont, size: CGFloat(settings.textSize))!,
+            .foregroundColor: settings.fill.uiColor(),
+            .strokeWidth: -settings.strokeWeight,
+            .strokeColor: settings.stroke.uiColor(),
+            .paragraphStyle: paragraphStyle!
+        ]
+    }
     
     /*
      * MARK: - VERTICES
@@ -230,6 +260,7 @@ import GameplayKit
     
     private func initializeGlobalContextStates() {
         Sketch.SketchSettings.defaultSettings(self)
+        setTextAttributes()
     }
     
     // ========================================================
@@ -252,8 +283,6 @@ import GameplayKit
         updateDimensions()
         updateTimes()
 
-        // Refresh all of the settings just in case to maintain state. At some point, we might be able to remove this. It is here as a precaution for now.
-        settings.reapplySettings(self)
         context?.saveGState()
         
         // Having two pushes (.saveGState() and below) might seem redundant, but UIGraphicsPush is necessary for UIImages.

--- a/Sources/SwiftProcessing/Core/SketchEnums.swift
+++ b/Sources/SwiftProcessing/Core/SketchEnums.swift
@@ -98,6 +98,7 @@ extension Sketch {
     public enum AlignmentY {
         case top
         case bottom
+        case center
         case baseline
     }
 

--- a/Sources/SwiftProcessing/Core/SketchTypography.swift
+++ b/Sources/SwiftProcessing/Core/SketchTypography.swift
@@ -174,11 +174,6 @@ public extension Sketch {
             x = x + xOffset
             attributedString.draw(in: CGRect(x: x, y: y, width: textSize.width, height: textSize.height))
         } else {
-            push()
-            stroke(255)
-            noFill()
-            rect(x, y, width, height)
-            pop()
             attributedString.draw(in:
                                     CGRect(
                                         x: x,

--- a/Sources/SwiftProcessing/Core/SketchTypography.swift
+++ b/Sources/SwiftProcessing/Core/SketchTypography.swift
@@ -18,6 +18,8 @@ public extension Sketch {
     
     func textSize<S: Numeric>(_ size: S) {
         settings.textSize = size.convert()
+        
+        setTextAttributes()
     }
     
     /// Sets the text font. For a list of pre-installed fonts on iOS, see here: https://developer.apple.com/fonts/system-fonts/#preinstalled
@@ -30,6 +32,8 @@ public extension Sketch {
     
     func textFont(_ name: String) {
         settings.textFont = name
+        
+        setTextAttributes()
     }
     
     /// Sets the text alignment horizontally and, optionally, vertically.
@@ -45,6 +49,10 @@ public extension Sketch {
     
     func textAlign(_ alignX: Alignment, _ alignY: AlignmentY = Default.textAlignY){
         settings.textAlign = alignX
+        setTextAttributes()
+        
+        // Vertical alignment is not supported by UIKit outside of control elements.
+        // We'll calculate it ourselves inside of text().
         settings.textAlignY = alignY
     }
     
@@ -60,6 +68,34 @@ public extension Sketch {
     
     func textLeading<L: Numeric>(_ leading: L) {
         settings.textLeading = leading.convert()
+        
+        setTextAttributes()
+    }
+    
+    /// Returns the text ascent (height above the baseline) of the current font and text size setting, i.e. the space between the baseline and the top of the font.
+    /// ```
+    /// textFont("HelveticaNeue")
+    /// textSize(65)
+    /// print(textAscent())
+    /// ```
+    
+    func textAscent() -> Double {
+        let currentFont = UIFont(name: settings.textFont, size: CGFloat(settings.textSize))
+        
+        return Double(currentFont?.ascender ?? 0.0)
+    }
+    
+    /// Returns the text descent (height below the baseline) of the current font and text size setting, i.e. the space between the baseline and the bottom of the font.
+    /// ```
+    /// textFont("HelveticaNeue")
+    /// textSize(65)
+    /// print(textDescent())
+    /// ```
+    
+    func textDescent() -> Double {
+        let currentFont = UIFont(name: settings.textFont, size: CGFloat(settings.textSize))
+        
+        return Double(currentFont?.descender ?? 0.0)
     }
     
     /// Draws a string of text to the screen using an x and y coordinate. Optionally you can specify a second x and y to draw within a rectangular space.
@@ -84,33 +120,71 @@ public extension Sketch {
         cg_x2 = x2?.convert()
         cg_y2 = y2?.convert()
         
-        let paragraphStyle = NSMutableParagraphStyle()
+        let attributedString = NSAttributedString(string: string,
+                                                  attributes: attributes)
         
-        var align: NSTextAlignment!
-        switch settings.textAlign {
-        case .left:
-            align = .left
-        case .right:
-            align = .right
+        let textSize = attributedString.size()
+        var xOffset: CGFloat = 0.0
+        var yOffset: CGFloat = 0.0
+        
+        switch attributedString.getAlignment() {
         case .center:
-            align = .center
+            xOffset = -textSize.width / 2
+        case .left:
+            xOffset = 0.0
+        case .right:
+            xOffset = -textSize.width
+        default:
+            print("No alignment initialized.")
         }
-        paragraphStyle.alignment = align
-        paragraphStyle.lineSpacing = CGFloat(settings.textLeading)
         
+        var x = cg_x
+        var y = cg_y
+        let width = (cg_x2 ?? CGFloat(width))
+        let height = (cg_y2 ?? CGFloat(height))
         
-        let attributes: [NSAttributedString.Key: Any] = [
-            .paragraphStyle: paragraphStyle,
-            .font: UIFont(name: settings.textFont, size: CGFloat(settings.textSize))!,
-            .foregroundColor: settings.fill.uiColor(),
-            .strokeWidth: -settings.strokeWeight,
-            .strokeColor: settings.stroke.uiColor()
-        ]
+        switch settings.textAlignY {
+        case .baseline:
+            if cg_y2 == nil {
+                yOffset = -textSize.height - CGFloat(textDescent())
+            } else {
+                yOffset = 0.0
+            }
+        case .bottom:
+            if cg_y2 == nil {
+                yOffset = -textSize.height
+            } else {
+                yOffset = height - textSize.height
+            }
+        case .top:
+            yOffset = 0.0
+        case .center:
+            if cg_y2 == nil {
+                yOffset = -textSize.height / 2
+            } else {
+                yOffset = (height - textSize.height) / 2
+            }
+        }
+        
+        y = y + yOffset
+        
+        // Because draw(at:) does not honor alignment, we need to use draw(in:), which takes a rect. This means that calculation needs to be done so that SwiftProcessing's alignment attributes are honored.
         
         if cg_x2 == nil {
-            string.draw(at: CGPoint(x: cg_x, y: cg_y), withAttributes: attributes)
+            x = x + xOffset
+            attributedString.draw(in: CGRect(x: x, y: y, width: textSize.width, height: textSize.height))
         } else {
-            string.draw(with: CGRect(x: cg_x, y: cg_y, width: (cg_x2 != nil) ? cg_x2! : CGFloat(width), height: (cg_y2 != nil) ? cg_y2! : CGFloat(height)), options: .usesLineFragmentOrigin, attributes: attributes, context: nil)
+            push()
+            stroke(255)
+            noFill()
+            rect(x, y, width, height)
+            pop()
+            attributedString.draw(in:
+                                    CGRect(
+                                        x: x,
+                                        y: y,
+                                        width: width,
+                                        height: height))
         }
     }
     
@@ -129,4 +203,23 @@ public extension Sketch {
         let cg_x2 = nil as CGFloat?
         text(string, x, y, cg_x1, cg_x2)
     }
+}
+
+
+extension NSAttributedString {
+    func getAlignment() -> NSTextAlignment {
+        
+        var alignment: NSTextAlignment?
+        
+        self.enumerateAttribute(NSAttributedString.Key.paragraphStyle, in: NSRange(location: 0, length: self.length), options: [], using: { (value, range, stop) -> Void in
+            guard let currentStyle = value as? NSParagraphStyle else {
+                print("Paragraph style not set.")
+                return
+            }
+            alignment = currentStyle.alignment
+        } )
+        
+        return alignment ?? .left
+    }
+    
 }

--- a/Sources/SwiftProcessing/Core/SketchVector.swift
+++ b/Sources/SwiftProcessing/Core/SketchVector.swift
@@ -346,7 +346,7 @@ public extension Sketch {
         ///      - v2: vector 2
         
         public static func dot(_ v1: Vector, _ v2: Vector) -> Double {
-            return v1.x * v2.x + v2.y * v2.y + v1.z * v2.z
+            return v1.x * v2.x + v1.y * v2.y + v1.z * v2.z
         }
         
         /// Returns the dot product of a vector with itself, which is the square of its magnitude.


### PR DESCRIPTION
## Typography
- Paragraph styles are now global within SwiftProcessing. Previously they would be instantiated with every `text()` call, which was an unnecessary extra step per frame. There is a single `NSMutableParagraphStyle` object in `Sketch.swift`. Potential improvement in #100 .
- Each call to a setting that modifies any text attributes calls a global function that updates the global `NSMutableParagraphStyle`.
- Within the `text()` function, `draw(at:)` was changed to `draw(in:)`. `NSString`'s `draw(at:)` method does not support paragraph alignment.
- Support was also added for reliable horizontal and vertical text alignment.
- Behavior of `text(string, x, y)` and `text(string, x, y, width, height)` has been tested and is consistent with the behavior of Processing (#112 )
- `textAscent()` and `textDescent()` were added for more fine grained control of typography.
- Added a `.center` for the `TextAlignY` enum which was a previous oversight.
- Added an extension to `NSAttributedString` to output its alignment.

## Playgrounds
- Added a little more info on the difference between putting `background()` in `setup()` and `draw()`.

## Default Changes
- Default leading was changed to reflect the 1.2 factor difference that Adobe uses in its software and has become a standard.
- In testing typography, it seemed strange that "HelveticaNeue-Thin" was the default. I removed the "-Thin" so that the SwiftProcessing default feels more default.

## Vector
- There was a typo in the `dot()` function that was leading to miscalculations. This has been fixed and is #111 .

## Settings Refreshing per Frame
- Settings refreshing for each frame has been removed. This was put in the draw loop as a precaution to ensure that state was cleared, but it really should not be necessary and may be masking other bugs that need to be addressed.

## Map
- Explored #110 and realized it's not a bug. This can be closed. The behavior is as expected and there is no bug.