### PR TITLE
Backpedaled on width/height being an Int.

### DIFF
--- a/Examples/Basics/Arrays.playground/Pages/Array.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Arrays.playground/Pages/Array.xcplaygroundpage/Contents.swift
@@ -24,7 +24,6 @@ class MySketch: Sketch, SketchDelegate {
     func draw() {
         var y1 = 0.0
         var y2 = height/3
-        print(y2)
         for i in 0...Int(width) {
           (stroke(coswave[i]*255),
           line(i, y1, i, y2))

--- a/Examples/Basics/Arrays.playground/Pages/Array.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Arrays.playground/Pages/Array.xcplaygroundpage/Contents.swift
@@ -24,6 +24,7 @@ class MySketch: Sketch, SketchDelegate {
     func draw() {
         var y1 = 0.0
         var y2 = height/3
+        print(y2)
         for i in 0...Int(width) {
           (stroke(coswave[i]*255),
           line(i, y1, i, y2))

--- a/Examples/Basics/Color.playground/Pages/Simple Linear Gradient.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Color.playground/Pages/Simple Linear Gradient.xcplaygroundpage/Contents.swift
@@ -17,10 +17,10 @@ class MySketch: Sketch, SketchDelegate {
     var b1:Color!, b2: Color!, c1: Color!, c2: Color!
     
     func setup() {
-        b1 = Color(255)
-        b2 = Color(0)
-        c1 = Color(204, 102, 0)
-        c2 = Color(0, 102, 153)
+        b1 = color(255)
+        b2 = color(0)
+        c1 = color(204, 102, 0)
+        c2 = color(0, 102, 153)
         
         noLoop()
     }

--- a/Examples/Basics/Conditionals.playground/contents.xcplayground
+++ b/Examples/Basics/Conditionals.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='raw' buildActiveScheme='true' importAppTypes='true'>
+<playground version='6.0' target-platform='ios' display-mode='rendered' buildActiveScheme='true' executeOnSourceChanges='true' importAppTypes='true'>
     <pages>
         <page name='Conditionals 1'/>
         <page name='Conditionals 2'/>

--- a/Examples/Basics/Data.playground/Pages/Datatype Conversion.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Data.playground/Pages/Datatype Conversion.xcplaygroundpage/Contents.swift
@@ -11,26 +11,26 @@ import PlaygroundSupport
 class MySketch: Sketch, SketchDelegate {
     
     func setup() {
-
+        
         background(0)
-
+        
         textFont("Menlo-Regular")
         textSize(24)
-
+        
         let c: Character    // Chars are used for storing alphanumeric symbols
         let d: Double   // Doubles are decimal numbers
         let i: Int    // Integers are values between 9,223,372,036,854,775,807 and -9,223,372,036,854,775,808
         let b: UInt8   // UInt8's are values between 0 and 255
-
+        
         c = "A"
         d = Double(c.asciiValue!)      // Sets d = 65.0
         i = Int(d * 1.4)  // Sets i to 91
         b = UInt8(c.asciiValue! / 2)   // Sets b to 32
-
+        
         //print(d)
         //print(i)
         //print(b)
-
+        
         text("The value of variable c is \(c)", 50, 100);
         text("The value of variable f is \(d)", 50, 150);
         text("The value of variable i is \(i)", 50, 200);

--- a/Examples/Basics/Data.playground/Pages/Integers Doubles.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Data.playground/Pages/Integers Doubles.xcplaygroundpage/Contents.swift
@@ -12,25 +12,25 @@ class MySketch: Sketch, SketchDelegate {
     
     var a: Int = 0;       // Create a variable "a" of the datatype "Int"
     var b: Double = 0.0;  // Create a variable "b" of the datatype "Double"
-
+    
     func setup() {
-      stroke(255)
+        stroke(255)
     }
-
+    
     func draw() {
-      (background(0))
-      
-      a = a + 1
-      b = b + 0.2
-      (line(a, 0, a, height/2))
-      (line(b, height/2, b, height))
-      
-      if a > width {
-        a = 0
-      }
-      if b > width {
-        b = 0
-      }
+        (background(0))
+        
+        a = a + 1
+        b = b + 0.2
+        (line(a, 0, a, height/2))
+        (line(b, height/2, b, height))
+        
+        if a > width {
+            a = 0
+        }
+        if b > width {
+            b = 0
+        }
     }
     
 }

--- a/Examples/Basics/Data.playground/Pages/True False.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Data.playground/Pages/True False.xcplaygroundpage/Contents.swift
@@ -12,36 +12,36 @@ class MySketch: Sketch, SketchDelegate {
     
     func setup() {
         var b = false
-
+        
         background(0)
         stroke(255)
-
+        
         let d = 20
         let middle = 320
-
+        
         // Center sketch
         translate((width-640)/2, (height-360)/2)
         
         for i in stride(from: d, through: 640, by: d) {
-          
-          if i < middle {
-            b = true
-          } else {
-            b = false
-          }
-          
-          if b == true {
-            // Vertical line
-            line(i, d, i, 360-d)
-          }
-          
-          if b == false {
-            // Horizontal line
-            line(middle, i - middle + d, 640-d, i - middle + d)
-          }
+            
+            if i < middle {
+                b = true
+            } else {
+                b = false
+            }
+            
+            if b == true {
+                // Vertical line
+                line(i, d, i, 360-d)
+            }
+            
+            if b == false {
+                // Horizontal line
+                line(middle, i - middle + d, 640-d, i - middle + d)
+            }
         }
     }
-
+    
     func draw() {
     }
     

--- a/Examples/Basics/Data.playground/Pages/Variables.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Data.playground/Pages/Variables.xcplaygroundpage/Contents.swift
@@ -19,23 +19,23 @@ class MySketch: Sketch, SketchDelegate {
         var a = 50
         var b = 120
         let c = 223
-
+        
         line(a, b, a+c, b)
         line(a, b+10, a+c, b+10)
         line(a, b+20, a+c, b+20)
         line(a, b+30, a+c, b+30)
-
+        
         a = a + c
         b = Int(height-b)
-
+        
         line(a, b, a+c, b)
         line(a, b+10, a+c, b+10)
         line(a, b+20, a+c, b+20)
         line(a, b+30, a+c, b+30)
-
+        
         a = a + c
         b = Int(height-b)
-
+        
         line(a, b, a+c, b)
         line(a, b+10, a+c, b+10)
         line(a, b+20, a+c, b+20)

--- a/Examples/Basics/Input.playground/Pages/Clock.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Input.playground/Pages/Clock.xcplaygroundpage/Contents.swift
@@ -31,11 +31,11 @@ class MySketch: Sketch, SketchDelegate {
     
     func draw() {
         (background(0),
-        
-        // Draw the clock background
-        fill(80),
-        noStroke(),
-        ellipse(cx, cy, clockDiameter, clockDiameter))
+         
+         // Draw the clock background
+         fill(80),
+         noStroke(),
+         ellipse(cx, cy, clockDiameter, clockDiameter))
         
         // Angles for sin() and cos() start at 3 o'clock;
         // subtract HALF_PI to make them start at the top
@@ -45,12 +45,12 @@ class MySketch: Sketch, SketchDelegate {
         
         // Draw the hands of the clock
         (stroke(255),
-        strokeWeight(1),
-        line(cx, cy, cx + cos(s) * secondsRadius, cy + sin(s) * secondsRadius),
-        strokeWeight(2),
-        line(cx, cy, cx + cos(m) * minutesRadius, cy + sin(m) * minutesRadius),
-        strokeWeight(4),
-        line(cx, cy, cx + cos(h) * hoursRadius, cy + sin(h) * hoursRadius))
+         strokeWeight(1),
+         line(cx, cy, cx + cos(s) * secondsRadius, cy + sin(s) * secondsRadius),
+         strokeWeight(2),
+         line(cx, cy, cx + cos(m) * minutesRadius, cy + sin(m) * minutesRadius),
+         strokeWeight(4),
+         line(cx, cy, cx + cos(h) * hoursRadius, cy + sin(h) * hoursRadius))
         
         // Draw the minute ticks
         strokeWeight(2)

--- a/Examples/Basics/Input.playground/Pages/Constrain.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Input.playground/Pages/Constrain.xcplaygroundpage/Contents.swift
@@ -38,9 +38,9 @@ class MySketch: Sketch, SketchDelegate {
         mx = (constrain(mx, inner, width - inner))
         my = (constrain(my, inner, height - inner))
         (fill(76),
-        rect(edge, edge, width-edge, height-edge),
-        fill(255),
-        ellipse(mx, my, radius, radius))
+         rect(edge, edge, width-edge, height-edge),
+         fill(255),
+         ellipse(mx, my, radius, radius))
     }
 }
 

--- a/Examples/Basics/Input.playground/Pages/Keyboard Functions.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Input.playground/Pages/Keyboard Functions.xcplaygroundpage/Contents.swift
@@ -31,7 +31,7 @@ class MySketch: Sketch, SketchDelegate {
         
         noStroke()
         colorMode(.hsb, numChars)
-        background(12)
+        background(numChars/2)
 
         // Set a hue value for each key
         for i in 0..<numChars {

--- a/Examples/Basics/Input.playground/Pages/Keyboard Functions.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Input.playground/Pages/Keyboard Functions.xcplaygroundpage/Contents.swift
@@ -32,7 +32,7 @@ class MySketch: Sketch, SketchDelegate {
         noStroke()
         colorMode(.hsb, numChars)
         background(numChars/2)
-
+        
         // Set a hue value for each key
         for i in 0..<numChars {
             colors.append(color(i, numChars, numChars))

--- a/Examples/Basics/Input.playground/Pages/Milliseconds.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Input.playground/Pages/Milliseconds.xcplaygroundpage/Contents.swift
@@ -20,8 +20,8 @@ class MySketch: Sketch, SketchDelegate {
     func draw() {
         for i in 0..<scale {
             (colorMode(.rgb, (i+1) * scale * 10),
-            fill(millis()%((i+1) * scale * 10)),
-            rect(i*scale, 0, scale, height))
+             fill(millis()%((i+1) * scale * 10)),
+             rect(i*scale, 0, scale, height))
         }
     }
     

--- a/Examples/Basics/Input.playground/Pages/Touch 1D.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Input.playground/Pages/Touch 1D.xcplaygroundpage/Contents.swift
@@ -1,7 +1,7 @@
 /*:
  ## Touch 1D
  
- Touch the sketch left and right to shift the balance. The "mouseX" variable is used to control both the size and color of the rectangles.
+ Touch (or click and drag) the sketch left and right to shift the balance. The "touchX" variable is used to control both the size and color of the rectangles.
  
  [Source](https://processing.org/examples/mouse1d.html)
  */

--- a/Examples/Basics/Input.playground/Pages/Touch 2D.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Input.playground/Pages/Touch 2D.xcplaygroundpage/Contents.swift
@@ -11,18 +11,18 @@ import PlaygroundSupport
 class MySketch: Sketch, SketchDelegate {
     
     func setup() {
-      noStroke()
+        noStroke()
         rectMode(.center)
     }
-
+    
     func draw() {
-      background(51)
-      fill(255, 204)
-      rect(touchX, height/2, touchY/2+10, touchY/2+10)
-      fill(255, 204)
-      let inverseX = width-touchX
-      let inverseY = height-touchY
-      rect(inverseX, height/2, (inverseY/2)+10, (inverseY/2)+10)
+        background(51)
+        fill(255, 204)
+        rect(touchX, height/2, touchY/2+10, touchY/2+10)
+        fill(255, 204)
+        let inverseX = width-touchX
+        let inverseY = height-touchY
+        rect(inverseX, height/2, (inverseY/2)+10, (inverseY/2)+10)
     }
     
 }

--- a/Examples/Basics/Math.playground/Pages/Additive Wave.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Math.playground/Pages/Additive Wave.xcplaygroundpage/Contents.swift
@@ -2,7 +2,7 @@
  ## Additive Wave
  
  by Daniel Shiffman
-
+ 
  Create a more complex wave by adding two waves together.
  
  [Source](https://processing.org/examples/additivewave.html)
@@ -26,7 +26,7 @@ class MySketch: Sketch, SketchDelegate {
         colorMode(.rgb, 255, 255, 255, 100)
         w = width + 16
         
-        for i in 0..<maxwaves {
+        for _ in 0..<maxwaves {
             amplitude.append(random(10,30))
             let period = random(100,300) // How many pixels before the wave repeats
             dx.append((Math.two_pi / period) * xspacing)
@@ -37,8 +37,8 @@ class MySketch: Sketch, SketchDelegate {
     
     func draw() {
         (background(0),
-        calcWave(),
-        renderWave())
+         calcWave(),
+         renderWave())
     }
     
     func calcWave() {
@@ -69,8 +69,8 @@ class MySketch: Sketch, SketchDelegate {
     func renderWave() {
         // A simple way to draw the wave with an ellipse at each location
         (noStroke(),
-        fill(255,50),
-        ellipseMode(.center))
+         fill(255,50),
+         ellipseMode(.center))
         for x in 0..<yvalues.count {
             (ellipse(x*xspacing,height/2+yvalues[x],16,16))
         }

--- a/Examples/Basics/Math.playground/Pages/Arctangent.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Math.playground/Pages/Arctangent.xcplaygroundpage/Contents.swift
@@ -52,13 +52,13 @@ class MySketch: Sketch, SketchDelegate {
         
         func display() {
             (sketch.pushMatrix(),
-            sketch.translate(x, y),
-            sketch.fill(255),
-            sketch.ellipse(0, 0, size, size),
-            sketch.rotate(angle),
-            sketch.fill(153, 204, 0),
-            sketch.ellipse(size/4, 0, size/2, size/2),
-            sketch.popMatrix())
+             sketch.translate(x, y),
+             sketch.fill(255),
+             sketch.ellipse(0, 0, size, size),
+             sketch.rotate(angle),
+             sketch.fill(153, 204, 0),
+             sketch.ellipse(size/4, 0, size/2, size/2),
+             sketch.popMatrix())
         }
     }
 }

--- a/Examples/Basics/Math.playground/Pages/Distance 1D.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Math.playground/Pages/Distance 1D.xcplaygroundpage/Contents.swift
@@ -1,0 +1,59 @@
+/*:
+ ## Distance 1D
+ 
+ Touch the sketch left and right to control the speed and direction of the moving shapes.
+ 
+ [Source](https://processing.org/examples/distance1d.html)
+ */
+import SwiftProcessing
+import PlaygroundSupport
+
+class MySketch: Sketch, SketchDelegate {
+    
+    var xpos1: Double!
+    var xpos2: Double!
+    var xpos3: Double!
+    var xpos4: Double!
+    var thin = 8
+    var thick = 36
+    
+    func setup() {
+        noStroke()
+        xpos1 = width / 2
+        xpos2 = width / 2
+        xpos3 = width / 2
+        xpos4 = width / 2
+    }
+    
+    func draw() {
+        (background(0))
+        
+        let mx = touchX * 0.4 - width / 5.0
+        
+        (fill(102),
+        rect(xpos2, 0, thick, height / 2),
+        fill(204),
+        rect(xpos1, 0, thin, height / 2),
+        fill(102),
+        rect(xpos4, height / 2, thick, height / 2),
+        fill(204),
+        rect(xpos3, height / 2, thin, height / 2))
+        
+        (xpos1 += mx / 16)
+        (xpos2 += mx / 64)
+        (xpos3 -= mx / 16)
+        (xpos4 -= mx / 64)
+        
+        if xpos1 < -thin  { xpos1 =  Double(width) }
+        if xpos1 >  width { xpos1 =  Double(-thin) }
+        if xpos2 < -thick { xpos2 =  Double(width) }
+        if xpos2 >  width { xpos2 =  Double(-thick) }
+        if xpos3 < -thin  { xpos3 =  Double(width) }
+        if xpos3 >  width { xpos3 =  Double(-thin) }
+        if xpos4 < -thick { xpos4 =  Double(width) }
+        if xpos4 >  width { xpos4 =  Double(-thick) }
+    }
+}
+
+PlaygroundPage.current.needsIndefiniteExecution = true
+PlaygroundPage.current.setLiveView(MySketch())

--- a/Examples/Basics/Math.playground/Pages/Double Random.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Math.playground/Pages/Double Random.xcplaygroundpage/Contents.swift
@@ -1,0 +1,38 @@
+/*:
+ ## Double Random
+ 
+ by Ira Greenberg
+ 
+ Using two random() calls and the point() function to create an irregular sawtooth line.
+ 
+ [Source](https://processing.org/examples/doublerandom.html)
+ */
+import SwiftProcessing
+import PlaygroundSupport
+
+class MySketch: Sketch, SketchDelegate {
+    
+    var totalPts = 300
+    var steps: Int!
+    
+    func setup() {
+        steps = totalPts + 1
+        stroke(255)
+        frameRate(1)
+    }
+    
+    func draw() {
+        background(0)
+        var rand = 0.0
+        for i in 1..<steps {
+            // You want the result of the division below to be a double.
+            let x: Double = width / steps
+            (point( x * i, (height/2) + random(-rand, rand) ))
+            (rand += random(-5, 5))
+        }
+    }
+    
+}
+
+PlaygroundPage.current.needsIndefiniteExecution = true
+PlaygroundPage.current.setLiveView(MySketch())

--- a/Examples/Basics/Math.playground/Pages/Increment Decrement.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Math.playground/Pages/Increment Decrement.xcplaygroundpage/Contents.swift
@@ -1,0 +1,52 @@
+/*:
+ ## Increment Decrement
+ 
+ Writing "a += 1" is equivalent to "a = a + 1". Writing "a -= 1" is equivalent to "a = a - 1".
+ 
+ [Source](https://processing.org/examples/incrementdecrement.html)
+ */
+import SwiftProcessing
+import PlaygroundSupport
+
+class MySketch: Sketch, SketchDelegate {
+    
+    var a: Int!
+    var b: Int!
+    var direction: Bool!
+    
+    func setup() {
+        colorMode(.rgb, width);
+        a = 0
+        b = width
+        direction = true
+        frameRate(30)
+    }
+    
+    func draw() {
+        a += 1
+        if a > width {
+            a = 0
+            direction = !direction
+        }
+        if direction == true {
+            (stroke(a))
+        } else {
+            (stroke(width-a))
+        }
+        (line(a, 0, a, height/2))
+        
+        b -= 1
+        if b < 0 {
+            b = width
+        }
+        if direction == true {
+            (stroke(width-b))
+        } else {
+            (stroke(b))
+        }
+        (line(b, height/2+1, b, height))
+    }
+}
+
+PlaygroundPage.current.needsIndefiniteExecution = true
+PlaygroundPage.current.setLiveView(MySketch())

--- a/Examples/Basics/Math.playground/Pages/Interpolate.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Math.playground/Pages/Interpolate.xcplaygroundpage/Contents.swift
@@ -1,0 +1,39 @@
+/*:
+ ## Linear Interpolation
+ 
+ Move the mouse across the screen and the symbol will follow. Between drawing each frame of the animation, the ellipse moves part of the distance (0.05) from its current position toward the cursor using the lerp() function.
+ 
+ [Source](https://processing.org/examples/interpolate.html)
+ */
+import SwiftProcessing
+import PlaygroundSupport
+
+class MySketch: Sketch, SketchDelegate {
+    
+    var x: Double = 0.0
+    var y: Double = 0.0
+    
+    func setup() {
+        noStroke()
+    }
+    
+    func draw() {
+        (background(51))
+        
+        // lerp() calculates a number between two numbers at a specific increment.
+        // The amt parameter is the amount to interpolate between the two values
+        // where 0.0 equal to the first point, 0.1 is very near the first point, 0.5
+        // is half-way in between, etc.
+        
+        // Here we are moving 5% of the way to the mouse location each frame
+        x = lerp(x, touchX, 0.05)
+        y = lerp(y, touchY, 0.05)
+        
+        (fill(255))
+        (stroke(255))
+        (ellipse(x, y, 66, 66))
+    }
+}
+
+PlaygroundPage.current.needsIndefiniteExecution = true
+PlaygroundPage.current.setLiveView(MySketch())

--- a/Examples/Basics/Math.playground/Pages/Map.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Math.playground/Pages/Map.xcplaygroundpage/Contents.swift
@@ -1,0 +1,29 @@
+/*:
+ ## Map
+ 
+ Use the map() function to take any number and scale it to a new number that is more useful for the project that you are working on. For example, use the numbers from the mouse position to control the size or color of a shape. In this example, the mouse’s x-coordinate (numbers between 0 and 360) are scaled to new numbers to define the color and size of a circle.
+ 
+ [Source](https://processing.org/examples/map.html)
+ */
+import SwiftProcessing
+import PlaygroundSupport
+
+class MySketch: Sketch, SketchDelegate {
+    
+    func setup() {
+        noStroke()
+    }
+    
+    func draw() {
+        background(0)
+        // Scale the touchX value from 0 to width to a range between 0 and 175
+        let c = map(touchX, 0, width, 0, 175)
+        // Scale the touchX value from 0 to width to a range between 40 and 300
+        let d = map(touchX, 0, width, 40, 500)
+        (fill(255, c, 0),
+        ellipse(width/2, height/2, d, d))
+    }
+}
+
+PlaygroundPage.current.needsIndefiniteExecution = true
+PlaygroundPage.current.setLiveView(MySketch())

--- a/Examples/Basics/Math.playground/Pages/Noise 1D.xcplaygroundpage/Contents.swift
+++ b/Examples/Basics/Math.playground/Pages/Noise 1D.xcplaygroundpage/Contents.swift
@@ -1,0 +1,42 @@
+/*:
+ ## Noise 1D
+ 
+ Using 1D Perlin Noise to assign location.
+ 
+ [Source](https://processing.org/examples/noise1d.html)
+ */
+import SwiftProcessing
+import PlaygroundSupport
+
+class MySketch: Sketch, SketchDelegate {
+    
+    var xoff = 0.0
+    var xincrement = 0.01
+    
+    func setup() {
+        background(0)
+        noStroke()
+    }
+    
+    func draw() {
+        // Create an alpha blended background
+        (fill(0, 10),
+        rect(0,0,width,height))
+        
+        //var n = random(0,width)
+        // Try this line instead of noise
+        
+        // Get a noise value based on xoff and scale it according to the window's width
+        let n = noise(xoff)*width
+        
+        // With each cycle, increment xoff
+        xoff += xincrement
+        
+        // Draw the ellipse at the value produced by perlin noise
+        (fill(200),
+        ellipse(n,height/2, 64, 64))
+    }
+}
+
+PlaygroundPage.current.needsIndefiniteExecution = true
+PlaygroundPage.current.setLiveView(MySketch())

--- a/Examples/Basics/Math.playground/contents.xcplayground
+++ b/Examples/Basics/Math.playground/contents.xcplayground
@@ -3,7 +3,13 @@
     <pages>
         <page name='Additive Wave'/>
         <page name='Arctangent'/>
+        <page name='Distance 1D'/>
         <page name='Distance 2D'/>
         <page name='NoiseWave'/>
+        <page name='Double Random'/>
+        <page name='Increment Decrement'/>
+        <page name='Interpolate'/>
+        <page name='Map'/>
+        <page name='Noise 1D'/>
     </pages>
 </playground>

--- a/Examples/PORTING_EXAMPLES.md
+++ b/Examples/PORTING_EXAMPLES.md
@@ -86,8 +86,8 @@ In Swift for loops have been given a major overhaul. C-style for loops you may b
   print(i)
  }
 
- // 2 - Note: width is a Double in SwiftProcessing, so we convert it to an Int.
- for i in 0..<Int(width) {
+ // 2
+ for i in 0..<width {
   print(i)
  }
 

--- a/Examples/PORTING_EXAMPLES.md
+++ b/Examples/PORTING_EXAMPLES.md
@@ -87,7 +87,7 @@ In Swift for loops have been given a major overhaul. C-style for loops you may b
  }
 
  // 2
- for i in 0..<width {
+ for i in 0..<Int(width) {
   print(i)
  }
 

--- a/Playgrounds/Basics.playground/Pages/Randomness.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Basics.playground/Pages/Randomness.xcplaygroundpage/Contents.swift
@@ -57,11 +57,9 @@ class MySketch: Sketch, SketchDelegate {
     var ySpeed0 = 0.0, ySpeed1 = 0.0, ySpeed2 = 0.0, ySpeed3 = 0.0, ySpeed4 = 0.0
     var maxSpeed = 10.0
 
-    // This is a partially transparent gray color.
-    // This is what gives our raindrops trails.
-    
-    var skyColor = Color(#colorLiteral(red: 0.2549019754, green: 0.2745098174, blue: 0.3019607961, alpha: 0.1))
-    var raindropColor = Color(#colorLiteral(red: 0.4745098054, green: 0.8392156959, blue: 0.9764705896, alpha: 1))
+    // Set up the color variables here as optionals.
+    var skyColor: Color!
+    var raindropColor: Color!
     
     var diameter0 = 0.0, diameter1 = 0.0, diameter2 = 0.0, diameter3 = 0.0, diameter4 = 0.0
     var maxDiameter = 50.0
@@ -69,6 +67,12 @@ class MySketch: Sketch, SketchDelegate {
     // We're going to generate our random numbers once at the beginning.
     
     func setup() {
+        // Initialize our colors here.
+        // This is a partially transparent gray color.
+        // This is what gives our raindrops trails.
+        skyColor = color(#colorLiteral(red: 0.2549019754, green: 0.2745098174, blue: 0.3019607961, alpha: 0.1))
+        raindropColor = color(#colorLiteral(red: 0.4745098054, green: 0.8392156959, blue: 0.9764705896, alpha: 1))
+        
         xPos0 = random(width)
         xPos1 = random(width)
         xPos2 = random(width)

--- a/Playgrounds/Interactivity and Control Flow.playground/Pages/For and While Loops.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Interactivity and Control Flow.playground/Pages/For and While Loops.xcplaygroundpage/Contents.swift
@@ -85,12 +85,17 @@ import UIKit
 
 class MySketch: Sketch, SketchDelegate {
     
-    var topColor = Color(#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1))
-    var bottomColor = Color(#colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1))
+    // Declare colors as optionals.
+    var topColor: Color!
+    var bottomColor: Color!
 
     var increment = 1.0 // Try increasing this increment to see what happens!
     
     func setup() {
+        // Initialize colors
+        topColor = color(#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1))
+        bottomColor = color(#colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1))
+        
         for i in stride(from: 0, to: height, by: increment) {
             (strokeWeight(increment),
              stroke(lerpColor(topColor, bottomColor, i/height)),

--- a/Playgrounds/Interactivity and Control Flow.playground/Pages/Map and Lerp.xcplaygroundpage/Contents.swift
+++ b/Playgrounds/Interactivity and Control Flow.playground/Pages/Map and Lerp.xcplaygroundpage/Contents.swift
@@ -72,15 +72,22 @@ class MySketch: Sketch, SketchDelegate {
     var targetX = 0.0
     var targetY = 0.0
     
-    // We're going to map between two colors from the
-    // top of the screen to the bottom to mimic sunset and sunrise.
-    var topColor = Color(#colorLiteral(red: 0.9686274529, green: 0.78039217, blue: 0.3450980484, alpha: 1))
-    var bottomColor = Color(#colorLiteral(red: 0.7450980544, green: 0.1568627506, blue: 0.07450980693, alpha: 1))
+    // Declare colors as optionals
+    var topColor: Color!
+    var bottomColor: Color!
     
-    var backgroundTop = Color(#colorLiteral(red: 0.2392156869, green: 0.6745098233, blue: 0.9686274529, alpha: 1))
-    var backgroundBottom = Color(#colorLiteral(red: 0.009056979678, green: 0, blue: 0.5434187807, alpha: 1))
+    var backgroundTop: Color!
+    var backgroundBottom: Color!
     
     func setup() {
+        // We're going to map between two colors from the
+        // top of the screen to the bottom to mimic sunset and sunrise.
+        topColor = color(#colorLiteral(red: 0.9686274529, green: 0.78039217, blue: 0.3450980484, alpha: 1))
+        bottomColor = color(#colorLiteral(red: 0.7450980544, green: 0.1568627506, blue: 0.07450980693, alpha: 1))
+        
+        backgroundTop = color(#colorLiteral(red: 0.2392156869, green: 0.6745098233, blue: 0.9686274529, alpha: 1))
+        backgroundBottom = color(#colorLiteral(red: 0.009056979678, green: 0, blue: 0.5434187807, alpha: 1))
+        
         // The default starting value for touchX and touchY is 0.0, so it will draw in the corner if we don't change it before draw is called.
         
         // Comment these out and see how the sketch changes.

--- a/Sources/SwiftProcessing/Core/NumericProtocolExtension.swift
+++ b/Sources/SwiftProcessing/Core/NumericProtocolExtension.swift
@@ -29,7 +29,7 @@ public protocol Numeric {
     init(_ v:UInt32)
     init(_ v:Int64)
     init(_ v:UInt64)
-    init(_ v: CGFloat)
+    init(_ v:CGFloat)
 }
 
 extension Float   : Numeric {func _asOther<T:Numeric>() -> T { return T(self) }}

--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -98,11 +98,11 @@ import GameplayKit
     /// The `Default` struct contains the defaults for the style states that SwiftProcessing keeps track of.
     
     public struct Default {
-        public static let backgroundColor = Color(204)
+        public static let backgroundColor = Color(204.0, 204.0, 204.0, 255.0)
         public static let colorMode = ColorMode.rgb
-        public static let fill = Color(255)
-        public static let stroke = Color(0.0)
-        public static let tint = Color(0.0, 0.0)
+        public static let fill = Color(255.0, 255.0, 255.0, 255.0)
+        public static let stroke = Color(0.0, 0.0, 0.0, 0.0)
+        public static let tint = Color(0.0, 0.0, 0.0, 0.0)
         public static let strokeWeight = 1.0
         public static let strokeJoin = StrokeJoin.miter
         public static let strokeCap = StrokeCap.round

--- a/Sources/SwiftProcessing/Core/Sketch.swift
+++ b/Sources/SwiftProcessing/Core/Sketch.swift
@@ -160,8 +160,8 @@ import GameplayKit
      */
     
     public weak var sketchDelegate: SketchDelegate?
-    public var width: Int = 0
-    public var height: Int = 0
+    public var width: Double = 0
+    public var height: Double = 0
     public var nativeWidth: Double = 0
     public var nativeHeight: Double = 0
     public let deviceWidth = Double(UIScreen.main.bounds.width)
@@ -237,14 +237,14 @@ import GameplayKit
         paragraphStyle?.lineSpacing = CGFloat(settings.textLeading)
         
         attributes = [
-            .font: UIFont(name: settings.textFont, size: CGFloat(settings.textSize)) ?? UIFont(name: Default.textFont, size: settings.textSize)!,
+            .font: UIFont(name: settings.textFont, size: CGFloat(settings.textSize)) ?? UIFont(name: Default.textFont, size: CGFloat(settings.textSize))!,
             .foregroundColor: settings.fill.uiColor(),
             .strokeWidth: -settings.strokeWeight,
             .strokeColor: settings.stroke.uiColor(),
             .paragraphStyle: paragraphStyle!
         ]
         
-        if UIFont(name: settings.textFont, size: settings.textSize) == nil && !fontErrorHasDisplayed {
+        if UIFont(name: settings.textFont, size: CGFloat(settings.textSize)) == nil && !fontErrorHasDisplayed {
             print("ERROR: It looks like the font you are trying to call isn't installed. Font file names are not always the same as the name the system refers to them as. You can find out the internal name by iterating through the installed fonts. See reference for textFont().")
             fontErrorHasDisplayed = true
         }
@@ -439,8 +439,8 @@ import GameplayKit
     }
     
     private func updateDimensions() {
-        self.width = Int(self.frame.width)
-        self.height = Int(self.frame.height)
+        self.width = self.frame.width
+        self.height = self.frame.height
         self.nativeWidth = Double(self.frame.width) * Double(UIScreen.main.scale)
         self.nativeHeight = Double(self.frame.height) * Double(UIScreen.main.scale)
         

--- a/Sources/SwiftProcessing/Core/SketchCalculation.swift
+++ b/Sources/SwiftProcessing/Core/SketchCalculation.swift
@@ -78,6 +78,12 @@ public protocol Calculation {
     
     func sq<N: Numeric>(_ num: N) -> N
     
+    /// Returns the square root of a number
+    /// - Parameter num: number to find the square root of.
+    /// - Returns: square root
+    
+    func sqrt<N: Numeric>(_ num: N) -> Double
+    
     /// Returns a decimal number raised to a given power.
     /// - Parameters:
     ///   - base: base value
@@ -93,6 +99,8 @@ public protocol Calculation {
     /// - Returns: The lesser of x and y. If x is equal to y, returns x.
     
     func min<T>(_ x: T, _ y: T) -> T where T : Comparable
+    
+    
 }
 
 extension Sketch: Calculation {
@@ -180,6 +188,12 @@ extension Sketch: Calculation {
     
     public func sq<N: Numeric>(_ num: N) -> N {
         return Foundation.pow(num as! Decimal, 2) as! N
+    }
+    
+    public func sqrt<N: Numeric>(_ num: N) -> Double {
+        let d_num: Double = num.convert()
+        
+        return Foundation.sqrt(d_num)
     }
     
     public func pow<B: Numeric, P: Numeric>(_ base: B, _ power: P) -> Double {

--- a/Sources/SwiftProcessing/Core/SketchColor.swift
+++ b/Sources/SwiftProcessing/Core/SketchColor.swift
@@ -40,7 +40,7 @@ public extension UIColor {
         return (h, s, b, a)
     }
     
-    var double_hsba: (hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat) {
+    var double_hsba: (hue: Double, saturation: Double, brightness: Double, alpha: Double) {
         var h: CGFloat = 0
         var s: CGFloat = 0
         var b: CGFloat = 0
@@ -803,16 +803,16 @@ public extension Sketch {
             switch normalized {
             case true:
                 // Set RGB
-                self.v1 = clamp(value: d_v1 * Color.v1Max, minimum: 0.0, maximum: Color.v1Max)
-                self.v2 = clamp(value: d_v2 * Color.v2Max, minimum: 0.0, maximum: Color.v2Max)
-                self.v3 = clamp(value: d_v3 * Color.v3Max, minimum: 0.0, maximum: Color.v3Max)
-                self.a = clamp(value: d_a * Color.alphaMax, minimum: 0.0, maximum: Color.alphaMax)
+                self.v1 = clamp(value: d_v1 * Double(Color.v1Max), minimum: 0.0, maximum: Double(Color.v1Max))
+                self.v2 = clamp(value: d_v2 * Double(Color.v2Max), minimum: 0.0, maximum: Double(Color.v2Max))
+                self.v3 = clamp(value: d_v3 * Double(Color.v3Max), minimum: 0.0, maximum: Double(Color.v3Max))
+                self.a = clamp(value: d_a * Double(Color.alphaMax), minimum: 0.0, maximum: Double(Color.alphaMax))
             case false:
                 // Set RGB
-                self.v1 = clamp(value: d_v1, minimum: 0.0, maximum: Color.v1Max)
-                self.v2 = clamp(value: d_v2, minimum: 0.0, maximum: Color.v2Max)
-                self.v3 = clamp(value: d_v3, minimum: 0.0, maximum: Color.v3Max)
-                self.a = clamp(value: d_a, minimum: 0.0, maximum: Color.alphaMax)
+                self.v1 = clamp(value: d_v1, minimum: 0.0, maximum: Double(Color.v1Max))
+                self.v2 = clamp(value: d_v2, minimum: 0.0, maximum: Double(Color.v2Max))
+                self.v3 = clamp(value: d_v3, minimum: 0.0, maximum: Double(Color.v3Max))
+                self.a = clamp(value: d_a, minimum: 0.0, maximum: Double(Color.alphaMax))
             }
 
         }
@@ -839,18 +839,18 @@ public extension Sketch {
         func uiColor() -> UIColor {
             switch mode {
             case .rgb:
-                return UIColor(red: v1 / Color.v1Max, green: v2 / Color.v2Max, blue: v3 / Color.v3Max, alpha: a / Color.alphaMax)
+                return UIColor(red: CGFloat(v1) / Color.v1Max, green: CGFloat(v2) / Color.v2Max, blue: CGFloat(v3) / Color.v3Max, alpha: CGFloat(a) / Color.alphaMax)
             case .hsb:
-                return UIColor(hue: v1 / Color.v1Max, saturation: v2 / Color.v2Max, brightness: v3 / Color.v3Max, alpha: a / Color.alphaMax)
+                return UIColor(hue: CGFloat(v1) / Color.v1Max, saturation: CGFloat(v2) / Color.v2Max, brightness: CGFloat(v3) / Color.v3Max, alpha: CGFloat(a) / Color.alphaMax)
             }
         }
         
         func cgColor() -> CGColor {
             switch mode {
             case .rgb:
-                return UIColor(red: v1 / Color.v1Max, green: v2 / Color.v2Max, blue: v3 / Color.v3Max, alpha: a / Color.alphaMax).cgColor
+                return UIColor(red: CGFloat(v1) / Color.v1Max, green: CGFloat(v2) / Color.v2Max, blue: CGFloat(v3) / Color.v3Max, alpha: CGFloat(a) / Color.alphaMax).cgColor
             case .hsb:
-                return UIColor(hue: v1 / Color.v1Max, saturation: v2 / Color.v2Max, brightness: v3 / Color.v3Max, alpha: a / Color.alphaMax).cgColor
+                return UIColor(hue: CGFloat(v1) / Color.v1Max, saturation: CGFloat(v2) / Color.v2Max, brightness: CGFloat(v3) / Color.v3Max, alpha: CGFloat(a) / Color.alphaMax).cgColor
             }
         }
         

--- a/Sources/SwiftProcessing/Core/SketchKeyboard.swift
+++ b/Sources/SwiftProcessing/Core/SketchKeyboard.swift
@@ -123,6 +123,8 @@ extension Sketch: Keyboard {
             return KeyCode.esc
         case .keyboardDeleteOrBackspace:
             return KeyCode.backspace
+        case .keyboardReturnOrEnter:
+            return KeyCode.enter
         default:
             return KeyCode.none
         }

--- a/Sources/SwiftProcessing/Core/SketchRandom.swift
+++ b/Sources/SwiftProcessing/Core/SketchRandom.swift
@@ -27,7 +27,12 @@ public extension Sketch {
     ///   - high: upper bound of the random value
     
     func random<L: Numeric, H: Numeric>(_ low: L = L(0), _ high: H = H(1)) -> Double {
-        return Double.random(in: low.convert()...high.convert())
+        
+        let d_low: Double = low.convert()
+        let d_high: Double = high.convert()
+        
+        // This behavior mimics p5.js by *always* returning a random number, even if the lower bound is higher than the upper bound. Processing exits out if low >= high and returns low.
+        return Double.random(in: Swift.min(d_low, d_high) ... Swift.max(d_low, d_high))
     }
     
     /// Generate a random floating point number from 0 and high value (inclusive).
@@ -41,7 +46,10 @@ public extension Sketch {
     ///   - high: upper bound of the value's current range
     
     func random<T: Numeric>(_ high: T = T(1)) -> Double {
-        return Double.random(in: 0.0...high.convert())
+        let d_high: Double = high.convert()
+        
+        // Ensures that random() always returns a value, even if a negative value is entered.
+        return Double.random(in: Swift.min(0.0, d_high) ... Swift.max(0.0, d_high))
     }
     
     /*

--- a/Sources/SwiftProcessing/Core/SketchVector.swift
+++ b/Sources/SwiftProcessing/Core/SketchVector.swift
@@ -323,7 +323,7 @@ public extension Sketch {
         /// ```
         
         open func mag() -> Double {
-            return sqrt(self.magSq())
+            return Foundation.sqrt(self.magSq())
         }
         
         /// Returns the magnitude squared of the vector. Uses the distance formula minus the square root. **Note:** This is faster than `mag()` if you are just trying to compare whether one object is farther than another and don't need exact distances.
@@ -372,7 +372,7 @@ public extension Sketch {
         ///      - v2: vector 2
         
         public static func dist(_ v1: Vector, _ v2: Vector) -> Double {
-            return sqrt(Foundation.pow(v2.x - v1.x, 2) + Foundation.pow(v2.y - v1.y, 2) + Foundation.pow(v2.z - v1.z, 2))
+            return Foundation.sqrt(Foundation.pow(v2.x - v1.x, 2) + Foundation.pow(v2.y - v1.y, 2) + Foundation.pow(v2.z - v1.z, 2))
         }
         
         /// Returns the distance betwen two vectors.


### PR DESCRIPTION
It made intuitive sense that points on a screen should be integers, as they are in Processing, but in the Swift ecosystem this causes all kinds of side effects and necessitates that beginners learn about casting too early. So we're moving back to Double. This makes code more simple and lets us keep our examples closer to their Processing / p5.js cousins.

Also fixed color examples that used the Color class initializer. This is not behavior that we want. We need to use a color function to properly detect whether we are in RGB or CMYK mode and to use less dependency injection. This also matches the pattern that Processing uses.